### PR TITLE
[Refactor] 클로버 미션 리스트 조회 API 응답 구조 수정

### DIFF
--- a/src/main/java/com/example/live_backend/domain/mission/Enum/MissionDifficulty.java
+++ b/src/main/java/com/example/live_backend/domain/mission/Enum/MissionDifficulty.java
@@ -1,5 +1,5 @@
 package com.example.live_backend.domain.mission.Enum;
 
 public enum MissionDifficulty {
-    EASY, NORMAL, HARD
+    VERY_EASY, EASY, NORMAL, HARD, VERY_HARD
 }

--- a/src/main/java/com/example/live_backend/domain/mission/controller/CloverMissionController.java
+++ b/src/main/java/com/example/live_backend/domain/mission/controller/CloverMissionController.java
@@ -4,7 +4,6 @@ import com.example.live_backend.domain.mission.dto.CloverMissionListResponseDto;
 import com.example.live_backend.domain.mission.dto.CloverMissionResponseDto;
 import com.example.live_backend.domain.mission.dto.CloverMissionStatusResponseDto;
 import com.example.live_backend.domain.mission.service.CloverMissionService;
-import com.example.live_backend.global.error.exception.CustomException;
 import com.example.live_backend.global.error.exception.ErrorCode;
 import com.example.live_backend.global.error.response.ResponseHandler;
 import io.swagger.v3.oas.annotations.Operation;
@@ -23,36 +22,22 @@ public class CloverMissionController {
 	private final CloverMissionService cloverMissionService;
 
 	@GetMapping
-	@Operation(summary = "클로버 미션 리스트 조회 ",
-		description = "클로버 미션 리스트를 조회합니다.")
+	@Operation(summary = "클로버 미션 리스트 조회 ", description = "클로버 미션 리스트를 조회합니다.")
 	public ResponseHandler<CloverMissionListResponseDto> getCloverMissionList() {
 
-		try {
-			log.info("클로버 미션 리스트(3개) 조회 API 호출");
-			CloverMissionListResponseDto response = cloverMissionService.getCloverMissionList();
+		CloverMissionListResponseDto response = cloverMissionService.getCloverMissionList();
 
-			log.info("클로버 미션 리스트 조회 완료 - 총 {}개 미션", response.getMissions().size());
-			return ResponseHandler.success(response);
-		} catch (Exception e) {
-			return ResponseHandler.error(ErrorCode.INTERNAL_SERVER_ERROR);
-		}
-
+		return ResponseHandler.success(response);
 	}
 
 	@GetMapping("/{userMissionId}")
 	@Operation(summary = "클로버 미션(1개) 상세 조회 ",
-		description = "클로버 미션 1개의 상세 정보를 조회합니다.")
+			description = "클로버 미션 1개의 상세 정보를 조회합니다.")
 	public ResponseHandler<CloverMissionResponseDto> getCloverMissionInfo(@PathVariable Long userMissionId) {
 
-		try {
-			log.info("클로버 미션 상세 조회 API 호출");
+		CloverMissionResponseDto response = cloverMissionService.getCloverMissionInfo(userMissionId);
 
-			CloverMissionResponseDto response = cloverMissionService.getCloverMissionInfo(userMissionId);
-
-			return ResponseHandler.success(response);
-		} catch (Exception e) {
-			return ResponseHandler.error(ErrorCode.INTERNAL_SERVER_ERROR);
-		}
+		return ResponseHandler.success(response);
 	}
 
 	@PatchMapping("/{userMissionId}/start")

--- a/src/main/java/com/example/live_backend/domain/mission/dto/CloverMissionListResponseDto.java
+++ b/src/main/java/com/example/live_backend/domain/mission/dto/CloverMissionListResponseDto.java
@@ -1,12 +1,14 @@
 package com.example.live_backend.domain.mission.dto;
 
+import com.example.live_backend.domain.mission.Enum.MissionCategory;
+import com.example.live_backend.domain.mission.Enum.MissionDifficulty;
+import com.example.live_backend.domain.mission.Enum.MissionStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
@@ -27,10 +29,18 @@ public class CloverMissionListResponseDto {
     public static class CloverMissionList {
 
         @Schema(description = "미션 기록 ID", example = "10")
-        private Long missionRecordId;
+        private Long userMissionId;
 
         @Schema(description = "미션 제목", example = "동료에게 안부 인사하기")
-        private String title;
-    }
+        private String missionTitle;
 
+        @Schema(description = "미션 수행 상태", example = "ASSIGNED / STARTED / PAUSED / COMPLETED")
+        private MissionStatus missionStatus;
+
+        @Schema(description = "미션 난이도", example = "VERY_EASY / EASY / NORMAL / HARD / VERY_HARD")
+        private MissionDifficulty missionDifficulty;
+
+        @Schema(description = "미션 카테고리", example = "RELATIONSHIP / ENVIRONMENT / HEALTH ...")
+        private MissionCategory missionCategory;
+    }
 }

--- a/src/main/java/com/example/live_backend/domain/mission/service/CloverMissionService.java
+++ b/src/main/java/com/example/live_backend/domain/mission/service/CloverMissionService.java
@@ -39,13 +39,14 @@ public class CloverMissionService {
             throw new CustomException(ErrorCode.MISSION_NOT_FOUND);
         }
 
-        log.info("조회된 클로버 미션 개수: {}", todayMissions.size());
-
         // MissionRecord 리스트를 TodayMissionDto 리스트로 변환
         List<CloverMissionListResponseDto.CloverMissionList> missionLists = todayMissions.stream()
                 .map(missionRecord -> CloverMissionListResponseDto.CloverMissionList.builder()
-                        .missionRecordId(missionRecord.getId())
+                        .userMissionId(missionRecord.getId())
                         .title(missionRecord.getMissionTitle())
+                        .missionStatus(missionRecord.getMissionStatus())
+                        .missionDifficulty(missionRecord.getMissionDifficulty())
+                        .missionCategory(missionRecord.getMissionCategory())
                         .build())
                 .toList();
 
@@ -54,7 +55,7 @@ public class CloverMissionService {
                 .missions(missionLists)
                 .build();
 
-        log.info("클로버 미션 리스트 조회 완료 - 총 {}개 미션", missionLists.size());
+        log.info("클로버 미션 리스트 미션 개수 - 총 {}개 미션", missionLists.size());
 
         return response;
     }


### PR DESCRIPTION
### ✅ PR 타입 (하나 이상 선택해주세요)

- [ ]  기능 추가
- [ ]  기능 삭제
- [x]  리팩토링 / 코드 개선
- [ ]  의존성 / 환경 설정 변경
- [ ]  버그 수정
- [ ]  기타 (하단에 설명)

&nbsp;
### ✨ 어떤 내용인가요?

> 기존의 클로버 미션 리스트 조회 API 수정

&nbsp;
### 🔍 작업 상세 내용

- [ ]  `CloverMissionListResponseDto` 수정
- [ ]  컨트롤러단에서 예외처리하는 부분 일관성 있게 수정(try-catch 삭제)
- [ ]  미션 난이도(`MissionDifficulty`) 3단계에서 5단계로 수정
- [ ] 클로버 미션 리스트 조회 단위 테스트 코드 작성 - 미션 리스트 조회 성공 / 미션이 없어서 조회 실패

&nbsp;
### 🔗 관련 이슈 (선택)
#27 