### PR TITLE
[Feat] 클로버 미션 리필

### DIFF
--- a/src/main/java/com/example/live_backend/domain/mission/controller/CloverMissionController.java
+++ b/src/main/java/com/example/live_backend/domain/mission/controller/CloverMissionController.java
@@ -40,8 +40,8 @@ public class CloverMissionController {
 			@PathVariable Long userMissionId,
 			@AuthenticationPrincipal PrincipalDetails userDetails) {
 
-		Long memberId = userDetails.getMemberId();
-		CloverMissionResponseDto response = cloverMissionService.getCloverMissionInfo(userMissionId, memberId);
+		Long userId = userDetails.getMemberId();
+		CloverMissionResponseDto response = cloverMissionService.getCloverMissionInfo(userMissionId, userId);
 
 		return ResponseHandler.success(response);
 	}
@@ -52,8 +52,8 @@ public class CloverMissionController {
 			@PathVariable Long userMissionId,
 			@AuthenticationPrincipal PrincipalDetails userDetails) {
 
-		Long memberId = userDetails.getMemberId();
-		CloverMissionStatusResponseDto response = cloverMissionService.startCloverMission(userMissionId, memberId);
+		Long userId = userDetails.getMemberId();
+		CloverMissionStatusResponseDto response = cloverMissionService.startCloverMission(userMissionId, userId);
 
 		return ResponseHandler.success(response);
 
@@ -65,8 +65,8 @@ public class CloverMissionController {
 			@PathVariable Long userMissionId,
 			@AuthenticationPrincipal PrincipalDetails userDetails) {
 
-		Long memberId = userDetails.getMemberId();
-		CloverMissionStatusResponseDto response = cloverMissionService.pauseCloverMission(userMissionId, memberId);
+		Long userId = userDetails.getMemberId();
+		CloverMissionStatusResponseDto response = cloverMissionService.pauseCloverMission(userMissionId, userId);
 
 		return ResponseHandler.success(response);
 	}
@@ -77,8 +77,19 @@ public class CloverMissionController {
 			@PathVariable Long userMissionId,
 			@AuthenticationPrincipal PrincipalDetails userDetails) {
 
-		Long memberId = userDetails.getMemberId();
-		CloverMissionStatusResponseDto response = cloverMissionService.completeCloverMission(userMissionId, memberId);
+		Long userId = userDetails.getMemberId();
+		CloverMissionStatusResponseDto response = cloverMissionService.completeCloverMission(userMissionId, userId);
+
+		return ResponseHandler.success(response);
+	}
+
+	@GetMapping("/refill")
+	@Operation(summary = "클로버 리필", description = "클로버 미션을 새롭게 할당합니다.")
+	public ResponseHandler<CloverMissionListResponseDto> refillCloverMission(
+			@AuthenticationPrincipal PrincipalDetails userDetails) {
+
+		Long userId = userDetails.getMemberId();
+		CloverMissionListResponseDto response = cloverMissionService.assignCloverMissionList(userId);
 
 		return ResponseHandler.success(response);
 	}

--- a/src/main/java/com/example/live_backend/domain/mission/service/CloverMissionService.java
+++ b/src/main/java/com/example/live_backend/domain/mission/service/CloverMissionService.java
@@ -18,7 +18,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
+
+import static java.util.Collections.emptyList;
 
 @Service
 @RequiredArgsConstructor
@@ -31,40 +32,42 @@ public class CloverMissionService {
     private final MemberRepository memberRepository;
     private final CloverMissionDtoConverter cloverMissionDtoConverter;
 
+    /**
+     * 사용자의 클로버 미션 목록을 조회합니다.
+     * 만약 오늘 날짜로 할당된 미션이 없다면, 새로운 미션을 자동으로 할당합니다.
+     */
     @Transactional
     public CloverMissionListResponseDto getCloverMissionList(Long userId) {
 
-        Optional<Member> member = memberRepository.findById(userId);
-
-        if (member.isEmpty()) {
-            throw new CustomException(ErrorCode.USER_NOT_FOUND);
-        }
-
+        Member member = findUser(userId);
         LocalDateTime searchDate = LocalDateTime.now();
-
         List<MissionRecord> todayMissions = missionRecordRepository.findCloverMissions(userId, searchDate);
 
         // 만약 오늘의 클로버 미션 리스트를 조회했는데 결과가 없다면 미션 할당받는 아래의 로직 수행
         if (todayMissions.isEmpty()) {
-
-            // 예외를 던지는게 아니라.. 가장 최근 설문 정보를 DB 에서 조회해와서 설문 내용 요약하고, 벡터DB 에서 유사성 검색해서 10개 뽑고 LLM 에 전달해서 최종 3개 뽑는 플로우
-            // 설문의 내용을 일단은 가져올 수가 없으니까 설문 내용을 하드코딩해서 기능 구현하도록 함
-            String tempSurveySummary = "집안에서 컴퓨터만 보고 있으니 너무 답답해요. 하늘이나 자연을 보면서 마음을 정화하고 싶고, 산책도 좋아요.";
-
-            List<Long> missionIds = vectorDBService.searchSimilarMissionsIds(tempSurveySummary, 3);
-
-            List<CloverMission> findMissions = cloverMissionRepository.findAllById(missionIds);
-
-            List<MissionRecord> newMissionRecordList = findMissions.stream()
-                    .map(cloverMission -> MissionRecord.fromCloverMission(cloverMission, member.get()))
-                    .toList();
-
-            List<MissionRecord> savedMissionRecordList = missionRecordRepository.saveAll(newMissionRecordList);
-
-            return CloverMissionListResponseDto.of(userId, savedMissionRecordList);
+            List<MissionRecord> newMissions = assignNewCloverMissions(member, emptyList());
+            return CloverMissionListResponseDto.of(userId, newMissions);
         }
 
         return CloverMissionListResponseDto.of(userId, todayMissions);
+    }
+
+    /**
+     * 사용자에게 새로운 클로버 미션 목록을 할당합니다.
+     */
+    @Transactional
+    public CloverMissionListResponseDto assignCloverMissionList(Long userId) {
+        Member member = findUser(userId);
+
+        List<MissionRecord> todayAllMissions = missionRecordRepository.findCloverMissions(userId, LocalDateTime.now());
+
+        List<Long> excludedMissionIds = todayAllMissions.stream()
+                .map(record -> record.getMissionId())
+                .toList();
+
+        List<MissionRecord> newMissions = assignNewCloverMissions(member, excludedMissionIds);
+
+        return CloverMissionListResponseDto.of(userId, newMissions);
     }
 
     @Transactional(readOnly = true)
@@ -146,4 +149,25 @@ public class CloverMissionService {
 
         return findByUserMissionId;
     }
+
+    private List<MissionRecord> assignNewCloverMissions(Member member, List<Long> excludedIds) {
+
+        // TODO: 향후 실제 설문 요약 로직으로 대체 필요
+        String tempSurveySummary = "집안에서 컴퓨터만 보고 있으니 너무 답답해요. 하늘이나 자연을 보면서 마음을 정화하고 싶고, 산책도 좋아요.";
+
+        List<Long> newMissionsIds = vectorDBService.searchSimilarMissionsIds(tempSurveySummary, 3, excludedIds);
+
+        List<CloverMission> findMissions = cloverMissionRepository.findAllById(newMissionsIds);
+        List<MissionRecord> newMissionRecordList = findMissions.stream()
+                .map(cloverMission -> MissionRecord.fromCloverMission(cloverMission, member))
+                .toList();
+
+        return missionRecordRepository.saveAll(newMissionRecordList);
+    }
+
+    private Member findUser(Long userId) {
+        return memberRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+
 }

--- a/src/main/java/com/example/live_backend/domain/mission/service/VectorDBService.java
+++ b/src/main/java/com/example/live_backend/domain/mission/service/VectorDBService.java
@@ -7,9 +7,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.document.Document;
 import org.springframework.ai.vectorstore.SearchRequest;
 import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.ai.vectorstore.filter.Filter;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 
 @Slf4j
@@ -23,14 +25,23 @@ public class VectorDBService {
      * 주어진 텍스트와 가장 유사한 클로버 미션을 검색합니다.
      * @param queryText 유사도 검색을 위한 사용자 상태 요약 텍스트(설문 요약본)
      * @param  count    검색할 미션의 개수
+     * @param  excludedMissionIds    검색 제외할 미션의 Id
      * @return 추천 미션 정보가 담긴 DTO 리스트
      */
-    public List<Long> searchSimilarMissionsIds(String queryText, int count) {
+    public List<Long> searchSimilarMissionsIds(String queryText, int count, List<Long> excludedMissionIds) {
 
-        SearchRequest request = SearchRequest.builder()
+        SearchRequest.Builder builder = SearchRequest.builder()
                 .query(queryText)
-                .topK(count)
-                .build();
+                .topK(count);
+
+        if (excludedMissionIds != null && !excludedMissionIds.isEmpty()) {
+            String excludedIdsString = excludedMissionIds.stream()
+                    .map(id -> "'" + id + "'")
+                    .collect(Collectors.joining(", ", "[", "]"));
+            builder.filterExpression("clover_mission_id not in " + excludedIdsString);
+        }
+
+        SearchRequest request = builder.build();
 
         List<Document> recommendedDocuments = vectorStore.similaritySearch(request);
 


### PR DESCRIPTION
### ✅ PR 타입 (하나 이상 선택해주세요)

- [x]  기능 추가
- [ ]  기능 삭제
- [x]  리팩토링 / 코드 개선
- [ ]  의존성 / 환경 설정 변경
- [ ]  버그 수정
- [ ]  기타 (하단에 설명)

&nbsp;
### ✨ 어떤 내용인가요?
> 사용자가 클로버 미션을 리필할 수 있는 기능을 추가하는 기능을 구현합니다.

&nbsp;
### 🔍 작업 상세 내용

- [x] 클로버 미션 리필 API 엔드포인트 추가
   - GET /api/v1/missions/clover/refill 엔드포인트를 구현
- [x] 미션 재할당(리필) 로직 구현
   - `assignCloverMissionList` 서비스 메서드를 구현
   - 당일 이미 할당된 미션들을 조회하여, Vector DB 검색 시 해당 미션들을 제외하고 새로운 미션을 추천받도록 로직을 구성

&nbsp;
### 💬 리뷰어에게 전달할 내용

> 당일 이미 받은 미션(todayAllMissions)을 `excludedMissionIds`로 만들어 Vector DB 검색에서 제외하는 부분이 핵심 로직이니 자세히 확인부탁드립니다!

&nbsp;
### 🔗 관련 이슈
#40 