### PR TITLE
[Feat/bookmark] 스크랩 조회 및 토글 기능 구현

### DIFF
--- a/src/main/java/com/example/live_backend/domain/board/dto/response/BoardDetailResponseDto.java
+++ b/src/main/java/com/example/live_backend/domain/board/dto/response/BoardDetailResponseDto.java
@@ -22,13 +22,15 @@ public class BoardDetailResponseDto {
     private final Long commentCount;
     private final Map<ReactionType, Long> reactionCounts;
     private final List<ReactionType> userReactions;
+    private final boolean isScraped;
     private final LocalDateTime createdAt;
     private final LocalDateTime modifiedAt;
 
     public BoardDetailResponseDto(Board board, String authorNickname, 
                                   Long commentCount,
                                   Map<ReactionType, Long> reactionCounts,
-                                  List<ReactionType> userReactions) {
+                                  List<ReactionType> userReactions,
+                                  boolean isScraped) {
         this.id = board.getId();
         this.title = board.getTitle();
         this.content = board.getContent();
@@ -42,6 +44,7 @@ public class BoardDetailResponseDto {
         this.commentCount = commentCount;
         this.reactionCounts = reactionCounts;
         this.userReactions = userReactions;
+        this.isScraped = isScraped;
         this.createdAt = board.getCreatedAt();
         this.modifiedAt = board.getModifiedAt();
     }

--- a/src/main/java/com/example/live_backend/domain/board/service/BoardService.java
+++ b/src/main/java/com/example/live_backend/domain/board/service/BoardService.java
@@ -22,6 +22,7 @@ import com.example.live_backend.domain.board.repository.BoardImageRepository;
 import com.example.live_backend.domain.board.repository.CommentRepository;
 import com.example.live_backend.domain.memeber.entity.Member;
 import com.example.live_backend.domain.memeber.repository.MemberRepository;
+import com.example.live_backend.domain.scrap.repository.ScrapRepository;
 import com.example.live_backend.global.error.exception.CustomException;
 import com.example.live_backend.global.error.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -45,6 +46,7 @@ public class BoardService {
     private final ImageRepository imageRepository;
     private final BoardImageRepository boardImageRepository;
     private final CommentRepository commentRepository;
+    private final ScrapRepository scrapRepository;
 
     /**
      * 게시글 생성 (관리자만 가능)
@@ -118,7 +120,15 @@ public class BoardService {
 
         Long commentCount = commentRepository.countByBoardId(boardId);
 
-        return new BoardDetailResponseDto(board, authorNickname, commentCount, reactionCounts, userReactions);
+        boolean isScraped = false;
+        if (memberId != null) {
+            Member member = memberRepository.findById(memberId).orElse(null);
+            if (member != null) {
+                isScraped = scrapRepository.existsByMemberAndBoard(member, board);
+            }
+        }
+
+        return new BoardDetailResponseDto(board, authorNickname, commentCount, reactionCounts, userReactions, isScraped);
     }
 
     /**

--- a/src/main/java/com/example/live_backend/domain/board/service/BoardService.java
+++ b/src/main/java/com/example/live_backend/domain/board/service/BoardService.java
@@ -122,10 +122,7 @@ public class BoardService {
 
         boolean isScraped = false;
         if (memberId != null) {
-            Member member = memberRepository.findById(memberId).orElse(null);
-            if (member != null) {
-                isScraped = scrapRepository.existsByMemberAndBoard(member, board);
-            }
+            isScraped = scrapRepository.existsByMemberIdAndBoardId(memberId, boardId);
         }
 
         return new BoardDetailResponseDto(board, authorNickname, commentCount, reactionCounts, userReactions, isScraped);

--- a/src/main/java/com/example/live_backend/domain/scrap/controller/ScrapController.java
+++ b/src/main/java/com/example/live_backend/domain/scrap/controller/ScrapController.java
@@ -1,6 +1,7 @@
 package com.example.live_backend.domain.scrap.controller;
 
 import com.example.live_backend.domain.board.dto.response.BoardListResponseDto;
+import com.example.live_backend.domain.scrap.controller.docs.ScrapControllerDocs;
 import com.example.live_backend.domain.scrap.dto.request.ScrapCursorRequestDto;
 import com.example.live_backend.domain.scrap.dto.request.ScrapDeleteRequestDto;
 import com.example.live_backend.domain.scrap.dto.response.ScrapToggleResponseDto;
@@ -9,24 +10,21 @@ import com.example.live_backend.global.page.CursorTemplate;
 import com.example.live_backend.global.error.response.ResponseHandler;
 import com.example.live_backend.global.security.PrincipalDetails;
 import com.example.live_backend.global.security.annotation.AuthenticatedApi;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "스크랩", description = "스크랩 관련 API")
 @RestController
 @RequestMapping("/api/v1/scraps")
 @RequiredArgsConstructor
-public class ScrapController {
+public class ScrapController implements ScrapControllerDocs {
 
     private final ScrapService scrapService;
 
-    @Operation(summary = "게시글 스크랩 토글", description = "게시글 스크랩을 추가하거나 취소합니다")
     @AuthenticatedApi(reason = "스크랩은 로그인한 사용자만 가능합니다")
     @PostMapping("/boards/{boardId}/toggle")
+    @Override
     public ResponseHandler<ScrapToggleResponseDto> toggleScrap(
             @AuthenticationPrincipal PrincipalDetails principalDetails,
             @PathVariable Long boardId) {
@@ -34,9 +32,9 @@ public class ScrapController {
         return ResponseHandler.success(ScrapToggleResponseDto.of(isScraped));
     }
 
-    @Operation(summary = "게시글 다중 스크랩 취소", description = "여러 게시글의 스크랩을 한번에 취소합니다")
     @AuthenticatedApi(reason = "스크랩 취소는 로그인한 사용자만 가능합니다")
     @DeleteMapping("/boards")
+    @Override
     public ResponseHandler<Void> removeScraps(
             @AuthenticationPrincipal PrincipalDetails principalDetails,
             @RequestBody @Valid ScrapDeleteRequestDto requestDto) {
@@ -44,9 +42,9 @@ public class ScrapController {
         return ResponseHandler.success(null);
     }
 
-    @Operation(summary = "스크랩 목록 조회", description = "사용자가 스크랩한 게시글 목록을 조회합니다")
     @AuthenticatedApi(reason = "스크랩 목록 조회는 로그인한 사용자만 가능합니다")
     @GetMapping
+    @Override
     public ResponseHandler<CursorTemplate<Long, BoardListResponseDto>> getScrapList(
             @AuthenticationPrincipal PrincipalDetails principalDetails,
             @ModelAttribute @Valid ScrapCursorRequestDto requestDto) {

--- a/src/main/java/com/example/live_backend/domain/scrap/controller/ScrapController.java
+++ b/src/main/java/com/example/live_backend/domain/scrap/controller/ScrapController.java
@@ -4,6 +4,7 @@ import com.example.live_backend.domain.board.dto.response.BoardListResponseDto;
 import com.example.live_backend.domain.scrap.controller.docs.ScrapControllerDocs;
 import com.example.live_backend.domain.scrap.dto.request.ScrapCursorRequestDto;
 import com.example.live_backend.domain.scrap.dto.request.ScrapDeleteRequestDto;
+import com.example.live_backend.domain.scrap.dto.response.ScrapDeleteResponseDto;
 import com.example.live_backend.domain.scrap.dto.response.ScrapToggleResponseDto;
 import com.example.live_backend.domain.scrap.service.ScrapService;
 import com.example.live_backend.global.page.CursorTemplate;
@@ -35,11 +36,11 @@ public class ScrapController implements ScrapControllerDocs {
     @AuthenticatedApi(reason = "스크랩 취소는 로그인한 사용자만 가능합니다")
     @DeleteMapping("/boards")
     @Override
-    public ResponseHandler<Void> removeScraps(
+    public ResponseHandler<ScrapDeleteResponseDto> removeScraps(
             @AuthenticationPrincipal PrincipalDetails principalDetails,
             @RequestBody @Valid ScrapDeleteRequestDto requestDto) {
-        scrapService.removeScraps(principalDetails.getMemberId(), requestDto);
-        return ResponseHandler.success(null);
+        ScrapDeleteResponseDto response = scrapService.removeScraps(principalDetails.getMemberId(), requestDto);
+        return ResponseHandler.success(response);
     }
 
     @AuthenticatedApi(reason = "스크랩 목록 조회는 로그인한 사용자만 가능합니다")

--- a/src/main/java/com/example/live_backend/domain/scrap/controller/ScrapController.java
+++ b/src/main/java/com/example/live_backend/domain/scrap/controller/ScrapController.java
@@ -1,0 +1,61 @@
+package com.example.live_backend.domain.scrap.controller;
+
+import com.example.live_backend.domain.board.dto.response.BoardListResponseDto;
+import com.example.live_backend.domain.scrap.dto.request.ScrapCursorRequestDto;
+import com.example.live_backend.domain.scrap.dto.request.ScrapDeleteRequestDto;
+import com.example.live_backend.domain.scrap.dto.response.ScrapToggleResponseDto;
+import com.example.live_backend.domain.scrap.service.ScrapService;
+import com.example.live_backend.global.page.CursorTemplate;
+import com.example.live_backend.global.error.response.ResponseHandler;
+import com.example.live_backend.global.security.PrincipalDetails;
+import com.example.live_backend.global.security.annotation.AuthenticatedApi;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "스크랩", description = "스크랩 관련 API")
+@RestController
+@RequestMapping("/api/v1/scraps")
+@RequiredArgsConstructor
+public class ScrapController {
+
+    private final ScrapService scrapService;
+
+    @Operation(summary = "게시글 스크랩 토글", description = "게시글 스크랩을 추가하거나 취소합니다")
+    @AuthenticatedApi(reason = "스크랩은 로그인한 사용자만 가능합니다")
+    @PostMapping("/boards/{boardId}/toggle")
+    public ResponseHandler<ScrapToggleResponseDto> toggleScrap(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @PathVariable Long boardId) {
+        boolean isScraped = scrapService.toggleScrap(principalDetails.getMemberId(), boardId);
+        return ResponseHandler.success(ScrapToggleResponseDto.of(isScraped));
+    }
+
+    @Operation(summary = "게시글 다중 스크랩 취소", description = "여러 게시글의 스크랩을 한번에 취소합니다")
+    @AuthenticatedApi(reason = "스크랩 취소는 로그인한 사용자만 가능합니다")
+    @DeleteMapping("/boards")
+    public ResponseHandler<Void> removeScraps(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @RequestBody @Valid ScrapDeleteRequestDto requestDto) {
+        scrapService.removeScraps(principalDetails.getMemberId(), requestDto);
+        return ResponseHandler.success(null);
+    }
+
+    @Operation(summary = "스크랩 목록 조회", description = "사용자가 스크랩한 게시글 목록을 조회합니다")
+    @AuthenticatedApi(reason = "스크랩 목록 조회는 로그인한 사용자만 가능합니다")
+    @GetMapping
+    public ResponseHandler<CursorTemplate<Long, BoardListResponseDto>> getScrapList(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @ModelAttribute @Valid ScrapCursorRequestDto requestDto) {
+        CursorTemplate<Long, BoardListResponseDto> response = scrapService.getScrapList(
+                principalDetails.getMemberId(), 
+                requestDto.getCursorId(), 
+                requestDto.getSize()
+        );
+        return ResponseHandler.success(response);
+    }
+
+}

--- a/src/main/java/com/example/live_backend/domain/scrap/controller/docs/ScrapControllerDocs.java
+++ b/src/main/java/com/example/live_backend/domain/scrap/controller/docs/ScrapControllerDocs.java
@@ -3,6 +3,7 @@ package com.example.live_backend.domain.scrap.controller.docs;
 import com.example.live_backend.domain.board.dto.response.BoardListResponseDto;
 import com.example.live_backend.domain.scrap.dto.request.ScrapCursorRequestDto;
 import com.example.live_backend.domain.scrap.dto.request.ScrapDeleteRequestDto;
+import com.example.live_backend.domain.scrap.dto.response.ScrapDeleteResponseDto;
 import com.example.live_backend.domain.scrap.dto.response.ScrapToggleResponseDto;
 import com.example.live_backend.global.error.response.ResponseHandler;
 import com.example.live_backend.global.page.CursorTemplate;
@@ -157,7 +158,10 @@ public interface ScrapControllerDocs {
                         "timestamp": "2024-01-01T12:00:00",
                         "success": true,
                         "message": "SUCCESS",
-                        "data": null,
+                        "data": {
+                            "requestedCount": 5,
+                            "deletedCount": 5
+                        },
                         "error": null
                     }
                     """)
@@ -202,7 +206,7 @@ public interface ScrapControllerDocs {
             )
         )
     })
-    ResponseHandler<Void> removeScraps(
+    ResponseHandler<ScrapDeleteResponseDto> removeScraps(
         @AuthenticationPrincipal PrincipalDetails principalDetails,
         @RequestBody @Valid ScrapDeleteRequestDto requestDto
     );

--- a/src/main/java/com/example/live_backend/domain/scrap/controller/docs/ScrapControllerDocs.java
+++ b/src/main/java/com/example/live_backend/domain/scrap/controller/docs/ScrapControllerDocs.java
@@ -1,0 +1,326 @@
+package com.example.live_backend.domain.scrap.controller.docs;
+
+import com.example.live_backend.domain.board.dto.response.BoardListResponseDto;
+import com.example.live_backend.domain.scrap.dto.request.ScrapCursorRequestDto;
+import com.example.live_backend.domain.scrap.dto.request.ScrapDeleteRequestDto;
+import com.example.live_backend.domain.scrap.dto.response.ScrapToggleResponseDto;
+import com.example.live_backend.global.error.response.ResponseHandler;
+import com.example.live_backend.global.page.CursorTemplate;
+import com.example.live_backend.global.security.PrincipalDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import jakarta.validation.Valid;
+
+@Tag(name = "스크랩", description = "게시글 스크랩 관리 API")
+public interface ScrapControllerDocs {
+
+    @Operation(
+        summary = "게시글 스크랩 토글",
+        description = """
+            게시글의 스크랩 상태를 토글합니다.
+            - 스크랩이 되어있지 않은 경우: 스크랩 추가
+            - 이미 스크랩된 경우: 스크랩 취소
+            
+            좋아요 기능과 동일한 토글 방식으로 동작합니다.
+            """,
+        parameters = {
+            @Parameter(
+                name = "boardId",
+                description = "스크랩할 게시글 ID",
+                required = true,
+                example = "1"
+            )
+        }
+    )
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "스크랩 토글 성공",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ResponseHandler.class),
+                examples = {
+                    @ExampleObject(
+                        name = "스크랩 추가",
+                        value = """
+                            {
+                                "timestamp": "2024-01-01T12:00:00",
+                                "success": true,
+                                "message": "SUCCESS",
+                                "data": {
+                                    "isScraped": true,
+                                    "message": "스크랩이 추가되었습니다."
+                                },
+                                "error": null
+                            }
+                            """
+                    ),
+                    @ExampleObject(
+                        name = "스크랩 취소",
+                        value = """
+                            {
+                                "timestamp": "2024-01-01T12:00:00",
+                                "success": true,
+                                "message": "SUCCESS",
+                                "data": {
+                                    "isScraped": false,
+                                    "message": "스크랩이 취소되었습니다."
+                                },
+                                "error": null
+                            }
+                            """
+                    )
+                }
+            )
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description = "인증 실패",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(value = """
+                    {
+                        "timestamp": "2024-01-01T12:00:00",
+                        "success": false,
+                        "message": "요청 처리 중 오류가 발생했습니다.",
+                        "data": null,
+                        "error": {
+                            "code": "DENIED_UNAUTHORIZED_USER",
+                            "message": "로그인되지 않은 유저의 접근입니다."
+                        }
+                    }
+                    """)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "게시글을 찾을 수 없음",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(value = """
+                    {
+                        "timestamp": "2024-01-01T12:00:00",
+                        "success": false,
+                        "message": "요청 처리 중 오류가 발생했습니다.",
+                        "data": null,
+                        "error": {
+                            "code": "BOARD_NOT_FOUND",
+                            "message": "존재하지 않는 게시글입니다."
+                        }
+                    }
+                    """)
+            )
+        )
+    })
+    ResponseHandler<ScrapToggleResponseDto> toggleScrap(
+        @AuthenticationPrincipal PrincipalDetails principalDetails,
+        @PathVariable Long boardId
+    );
+
+    @Operation(
+        summary = "게시글 다중 스크랩 취소",
+        description = """
+            여러 게시글의 스크랩을 한번에 취소합니다.
+            스크랩 목록 편집 모드에서 선택한 게시글들을 일괄 삭제할 때 사용됩니다.
+            최대 100개까지 한번에 삭제 가능합니다.
+            """,
+        requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "삭제할 게시글 ID 목록",
+            required = true,
+            content = @Content(
+                schema = @Schema(implementation = ScrapDeleteRequestDto.class),
+                examples = @ExampleObject(value = """
+                    {
+                        "boardIds": [1, 2, 3, 4, 5]
+                    }
+                    """)
+            )
+        )
+    )
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "다중 스크랩 삭제 성공",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(value = """
+                    {
+                        "timestamp": "2024-01-01T12:00:00",
+                        "success": true,
+                        "message": "SUCCESS",
+                        "data": null,
+                        "error": null
+                    }
+                    """)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "잘못된 요청 (빈 배열, 100개 초과 등)",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(value = """
+                    {
+                        "timestamp": "2024-01-01T12:00:00",
+                        "success": false,
+                        "message": "요청 처리 중 오류가 발생했습니다.",
+                        "data": null,
+                        "error": {
+                            "code": "INVALID_INPUT_VALUE",
+                            "message": "잘못된 입력값입니다."
+                        }
+                    }
+                    """)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description = "인증 실패",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(value = """
+                    {
+                        "timestamp": "2024-01-01T12:00:00",
+                        "success": false,
+                        "message": "요청 처리 중 오류가 발생했습니다.",
+                        "data": null,
+                        "error": {
+                            "code": "DENIED_UNAUTHORIZED_USER",
+                            "message": "로그인되지 않은 유저의 접근입니다."
+                        }
+                    }
+                    """)
+            )
+        )
+    })
+    ResponseHandler<Void> removeScraps(
+        @AuthenticationPrincipal PrincipalDetails principalDetails,
+        @RequestBody @Valid ScrapDeleteRequestDto requestDto
+    );
+
+    @Operation(
+        summary = "스크랩 목록 조회",
+        description = """
+            사용자가 스크랩한 게시글 목록을 조회합니다.
+            커서 기반 페이징을 사용하여 무한 스크롤을 지원합니다.
+            최신 스크랩순으로 정렬됩니다.
+            """,
+        parameters = {
+            @Parameter(
+                name = "cursorId",
+                description = "커서 ID (다음 페이지 조회시 사용)",
+                required = false,
+                example = "10"
+            ),
+            @Parameter(
+                name = "size",
+                description = "한 페이지당 조회할 개수 (1-100, 기본값: 20)",
+                required = false,
+                example = "20"
+            )
+        }
+    )
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "스크랩 목록 조회 성공",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ResponseHandler.class),
+                examples = @ExampleObject(value = """
+                    {
+                        "timestamp": "2024-01-01T12:00:00",
+                        "success": true,
+                        "message": "SUCCESS",
+                        "data": {
+                            "hasNext": true,
+                            "nextCursor": 45,
+                            "content": [
+                                {
+                                    "id": 50,
+                                    "title": "최신 스크랩한 게시글",
+                                    "category": {
+                                        "id": 1,
+                                        "name": "공지사항"
+                                    },
+                                    "relatedOrganization": "서울시",
+                                    "thumbnailImageUrl": "https://example.com/image1.jpg",
+                                    "authorNickname": "관리자",
+                                    "viewCount": 150,
+                                    "totalReactionCount": 0,
+                                    "createdAt": "2024-01-01T10:00:00"
+                                },
+                                {
+                                    "id": 48,
+                                    "title": "두번째 스크랩 게시글",
+                                    "category": {
+                                        "id": 2,
+                                        "name": "정책뉴스"
+                                    },
+                                    "relatedOrganization": "보건복지부",
+                                    "thumbnailImageUrl": null,
+                                    "authorNickname": "정책담당자",
+                                    "viewCount": 85,
+                                    "totalReactionCount": 0,
+                                    "createdAt": "2023-12-31T15:30:00"
+                                }
+                            ]
+                        },
+                        "error": null
+                    }
+                    """)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description = "인증 실패",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(value = """
+                    {
+                        "timestamp": "2024-01-01T12:00:00",
+                        "success": false,
+                        "message": "요청 처리 중 오류가 발생했습니다.",
+                        "data": null,
+                        "error": {
+                            "code": "DENIED_UNAUTHORIZED_USER",
+                            "message": "로그인되지 않은 유저의 접근입니다."
+                        }
+                    }
+                    """)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "사용자를 찾을 수 없음",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(value = """
+                    {
+                        "timestamp": "2024-01-01T12:00:00",
+                        "success": false,
+                        "message": "요청 처리 중 오류가 발생했습니다.",
+                        "data": null,
+                        "error": {
+                            "code": "MEMBER_NOT_FOUND",
+                            "message": "존재하지 않는 회원입니다."
+                        }
+                    }
+                    """)
+            )
+        )
+    })
+    ResponseHandler<CursorTemplate<Long, BoardListResponseDto>> getScrapList(
+        @AuthenticationPrincipal PrincipalDetails principalDetails,
+        @ModelAttribute @Valid ScrapCursorRequestDto requestDto
+    );
+}

--- a/src/main/java/com/example/live_backend/domain/scrap/controller/docs/ScrapControllerDocs.java
+++ b/src/main/java/com/example/live_backend/domain/scrap/controller/docs/ScrapControllerDocs.java
@@ -260,7 +260,7 @@ public interface ScrapControllerDocs {
                                     "thumbnailImageUrl": "https://example.com/image1.jpg",
                                     "authorNickname": "관리자",
                                     "viewCount": 150,
-                                    "totalReactionCount": 0,
+                                    "totalReactionCount": null,
                                     "createdAt": "2024-01-01T10:00:00"
                                 },
                                 {
@@ -274,7 +274,7 @@ public interface ScrapControllerDocs {
                                     "thumbnailImageUrl": null,
                                     "authorNickname": "정책담당자",
                                     "viewCount": 85,
-                                    "totalReactionCount": 0,
+                                    "totalReactionCount": null,
                                     "createdAt": "2023-12-31T15:30:00"
                                 }
                             ]

--- a/src/main/java/com/example/live_backend/domain/scrap/dto/request/ScrapCursorRequestDto.java
+++ b/src/main/java/com/example/live_backend/domain/scrap/dto/request/ScrapCursorRequestDto.java
@@ -1,0 +1,17 @@
+package com.example.live_backend.domain.scrap.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ScrapCursorRequestDto {
+    
+    private Long cursorId;
+    
+    @Min(value = 1, message = "size는 1 이상이어야 합니다")
+    @Max(value = 100, message = "size는 100 이하여야 합니다")
+    private int size = 20;
+}

--- a/src/main/java/com/example/live_backend/domain/scrap/dto/request/ScrapDeleteRequestDto.java
+++ b/src/main/java/com/example/live_backend/domain/scrap/dto/request/ScrapDeleteRequestDto.java
@@ -1,0 +1,17 @@
+package com.example.live_backend.domain.scrap.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class ScrapDeleteRequestDto {
+    
+    @NotEmpty(message = "삭제할 게시글 ID를 입력해주세요")
+    @Size(max = 100, message = "한 번에 최대 100개까지 삭제 가능합니다")
+    private List<Long> boardIds;
+}

--- a/src/main/java/com/example/live_backend/domain/scrap/dto/response/ScrapDeleteResponseDto.java
+++ b/src/main/java/com/example/live_backend/domain/scrap/dto/response/ScrapDeleteResponseDto.java
@@ -1,0 +1,23 @@
+package com.example.live_backend.domain.scrap.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ScrapDeleteResponseDto {
+    
+    private int requestedCount;
+    private int deletedCount;
+    
+    public static ScrapDeleteResponseDto of(int requestedCount, int deletedCount) {
+        return ScrapDeleteResponseDto.builder()
+                .requestedCount(requestedCount)
+                .deletedCount(deletedCount)
+                .build();
+    }
+}

--- a/src/main/java/com/example/live_backend/domain/scrap/dto/response/ScrapMessage.java
+++ b/src/main/java/com/example/live_backend/domain/scrap/dto/response/ScrapMessage.java
@@ -1,0 +1,13 @@
+package com.example.live_backend.domain.scrap.dto.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ScrapMessage {
+    SCRAP_ADDED("스크랩이 추가되었습니다."),
+    SCRAP_REMOVED("스크랩이 취소되었습니다.");
+
+    private final String message;
+}

--- a/src/main/java/com/example/live_backend/domain/scrap/dto/response/ScrapToggleResponseDto.java
+++ b/src/main/java/com/example/live_backend/domain/scrap/dto/response/ScrapToggleResponseDto.java
@@ -1,0 +1,16 @@
+package com.example.live_backend.domain.scrap.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ScrapToggleResponseDto {
+    private final boolean isScraped;
+    private final String message;
+    
+    public static ScrapToggleResponseDto of(boolean isScraped) {
+        String message = isScraped ? "스크랩이 추가되었습니다." : "스크랩이 취소되었습니다.";
+        return new ScrapToggleResponseDto(isScraped, message);
+    }
+}

--- a/src/main/java/com/example/live_backend/domain/scrap/dto/response/ScrapToggleResponseDto.java
+++ b/src/main/java/com/example/live_backend/domain/scrap/dto/response/ScrapToggleResponseDto.java
@@ -10,7 +10,7 @@ public class ScrapToggleResponseDto {
     private final String message;
     
     public static ScrapToggleResponseDto of(boolean isScraped) {
-        String message = isScraped ? "스크랩이 추가되었습니다." : "스크랩이 취소되었습니다.";
+        String message = isScraped ? ScrapMessage.SCRAP_ADDED.getMessage() : ScrapMessage.SCRAP_REMOVED.getMessage();
         return new ScrapToggleResponseDto(isScraped, message);
     }
 }

--- a/src/main/java/com/example/live_backend/domain/scrap/entity/Scrap.java
+++ b/src/main/java/com/example/live_backend/domain/scrap/entity/Scrap.java
@@ -1,0 +1,38 @@
+package com.example.live_backend.domain.scrap.entity;
+
+import com.example.live_backend.domain.BaseEntity;
+import com.example.live_backend.domain.board.entity.Board;
+import com.example.live_backend.domain.memeber.entity.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "scraps",
+    uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"member_id", "board_id"})
+    })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Scrap extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id", nullable = false)
+    private Board board;
+
+    @Builder
+    public Scrap(Member member, Board board) {
+        this.member = member;
+        this.board = board;
+    }
+}

--- a/src/main/java/com/example/live_backend/domain/scrap/repository/ScrapRepository.java
+++ b/src/main/java/com/example/live_backend/domain/scrap/repository/ScrapRepository.java
@@ -1,0 +1,24 @@
+package com.example.live_backend.domain.scrap.repository;
+
+import com.example.live_backend.domain.board.entity.Board;
+import com.example.live_backend.domain.memeber.entity.Member;
+import com.example.live_backend.domain.scrap.entity.Scrap;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ScrapRepository extends JpaRepository<Scrap, Long>, ScrapRepositoryCustom {
+
+    boolean existsByMemberAndBoard(Member member, Board board);
+
+    Optional<Scrap> findByMemberAndBoard(Member member, Board board);
+
+    @Modifying
+    @Query("DELETE FROM Scrap s WHERE s.member = :member AND s.board.id IN :boardIds")
+    void deleteByMemberAndBoardIds(@Param("member") Member member, @Param("boardIds") List<Long> boardIds);
+
+}

--- a/src/main/java/com/example/live_backend/domain/scrap/repository/ScrapRepository.java
+++ b/src/main/java/com/example/live_backend/domain/scrap/repository/ScrapRepository.java
@@ -25,6 +25,6 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long>, ScrapReposi
 
     @Modifying
     @Query("DELETE FROM Scrap s WHERE s.member = :member AND s.board.id IN :boardIds")
-    void deleteByMemberAndBoardIds(@Param("member") Member member, @Param("boardIds") List<Long> boardIds);
+    int deleteByMemberAndBoardIds(@Param("member") Member member, @Param("boardIds") List<Long> boardIds);
 
 }

--- a/src/main/java/com/example/live_backend/domain/scrap/repository/ScrapRepository.java
+++ b/src/main/java/com/example/live_backend/domain/scrap/repository/ScrapRepository.java
@@ -16,6 +16,12 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long>, ScrapReposi
     boolean existsByMemberAndBoard(Member member, Board board);
 
     Optional<Scrap> findByMemberAndBoard(Member member, Board board);
+    
+    @Query("SELECT s FROM Scrap s WHERE s.member.id = :memberId AND s.board.id = :boardId")
+    Optional<Scrap> findByMemberIdAndBoardId(@Param("memberId") Long memberId, @Param("boardId") Long boardId);
+    
+    @Query("SELECT CASE WHEN COUNT(s) > 0 THEN true ELSE false END FROM Scrap s WHERE s.member.id = :memberId AND s.board.id = :boardId")
+    boolean existsByMemberIdAndBoardId(@Param("memberId") Long memberId, @Param("boardId") Long boardId);
 
     @Modifying
     @Query("DELETE FROM Scrap s WHERE s.member = :member AND s.board.id IN :boardIds")

--- a/src/main/java/com/example/live_backend/domain/scrap/repository/ScrapRepositoryCustom.java
+++ b/src/main/java/com/example/live_backend/domain/scrap/repository/ScrapRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.example.live_backend.domain.scrap.repository;
+
+import com.example.live_backend.domain.board.dto.response.BoardListResponseDto;
+import com.example.live_backend.domain.memeber.entity.Member;
+import com.example.live_backend.global.page.CursorTemplate;
+
+public interface ScrapRepositoryCustom {
+    
+    CursorTemplate<Long, BoardListResponseDto> findScrapsByMemberWithCursor(Member member, Long cursorId, int size);
+}

--- a/src/main/java/com/example/live_backend/domain/scrap/repository/ScrapRepositoryImpl.java
+++ b/src/main/java/com/example/live_backend/domain/scrap/repository/ScrapRepositoryImpl.java
@@ -48,7 +48,7 @@ public class ScrapRepositoryImpl implements ScrapRepositoryCustom {
                 .map(s -> new BoardListResponseDto(
                         s.getBoard(), 
                         s.getBoard().getAuthor().getProfile().getNickname(),
-                        0L
+                        null  // 스크랩 목록에서는 반응 수를 제공하지 않음
                 ))
                 .toList();
 

--- a/src/main/java/com/example/live_backend/domain/scrap/repository/ScrapRepositoryImpl.java
+++ b/src/main/java/com/example/live_backend/domain/scrap/repository/ScrapRepositoryImpl.java
@@ -14,6 +14,8 @@ import java.util.stream.Collectors;
 
 import static com.example.live_backend.domain.scrap.entity.QScrap.scrap;
 import static com.example.live_backend.domain.board.entity.QBoard.board;
+import static com.example.live_backend.domain.memeber.entity.QMember.member;
+import static com.example.live_backend.domain.board.entity.QCategory.category;
 
 @Repository
 @RequiredArgsConstructor
@@ -22,12 +24,14 @@ public class ScrapRepositoryImpl implements ScrapRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public CursorTemplate<Long, BoardListResponseDto> findScrapsByMemberWithCursor(Member member, Long cursorId, int size) {
+    public CursorTemplate<Long, BoardListResponseDto> findScrapsByMemberWithCursor(Member targetMember, Long cursorId, int size) {
         List<Scrap> scraps = queryFactory
                 .selectFrom(scrap)
                 .join(scrap.board, board).fetchJoin()
+                .join(board.author, member).fetchJoin()
+                .join(board.category, category).fetchJoin()
                 .where(
-                        scrap.member.eq(member),
+                        scrap.member.eq(targetMember),
                         scrap.board.isDeleted.eq(false),
                         cursorCondition(cursorId)
                 )
@@ -46,7 +50,7 @@ public class ScrapRepositoryImpl implements ScrapRepositoryCustom {
                         s.getBoard().getAuthor().getProfile().getNickname(),
                         0L
                 ))
-                .collect(Collectors.toList());
+                .toList();
 
         if (hasNext && !scraps.isEmpty()) {
             Long nextCursor = scraps.get(scraps.size() - 1).getId();

--- a/src/main/java/com/example/live_backend/domain/scrap/repository/ScrapRepositoryImpl.java
+++ b/src/main/java/com/example/live_backend/domain/scrap/repository/ScrapRepositoryImpl.java
@@ -1,0 +1,62 @@
+package com.example.live_backend.domain.scrap.repository;
+
+import com.example.live_backend.domain.board.dto.response.BoardListResponseDto;
+import com.example.live_backend.domain.memeber.entity.Member;
+import com.example.live_backend.domain.scrap.entity.Scrap;
+import com.example.live_backend.global.page.CursorTemplate;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.example.live_backend.domain.scrap.entity.QScrap.scrap;
+import static com.example.live_backend.domain.board.entity.QBoard.board;
+
+@Repository
+@RequiredArgsConstructor
+public class ScrapRepositoryImpl implements ScrapRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public CursorTemplate<Long, BoardListResponseDto> findScrapsByMemberWithCursor(Member member, Long cursorId, int size) {
+        List<Scrap> scraps = queryFactory
+                .selectFrom(scrap)
+                .join(scrap.board, board).fetchJoin()
+                .where(
+                        scrap.member.eq(member),
+                        scrap.board.isDeleted.eq(false),
+                        cursorCondition(cursorId)
+                )
+                .orderBy(scrap.id.desc())
+                .limit(size + 1)
+                .fetch();
+
+        boolean hasNext = scraps.size() > size;
+        if (hasNext) {
+            scraps = scraps.subList(0, size);
+        }
+
+        List<BoardListResponseDto> boardDtos = scraps.stream()
+                .map(s -> new BoardListResponseDto(
+                        s.getBoard(), 
+                        s.getBoard().getAuthor().getProfile().getNickname(),
+                        0L
+                ))
+                .collect(Collectors.toList());
+
+        if (hasNext && !scraps.isEmpty()) {
+            Long nextCursor = scraps.get(scraps.size() - 1).getId();
+            return CursorTemplate.ofWithNextCursor(nextCursor, boardDtos);
+        } else {
+            return CursorTemplate.of(boardDtos);
+        }
+    }
+
+    private BooleanExpression cursorCondition(Long cursorId) {
+        return cursorId != null ? scrap.id.lt(cursorId) : null;
+    }
+}

--- a/src/main/java/com/example/live_backend/domain/scrap/service/ScrapService.java
+++ b/src/main/java/com/example/live_backend/domain/scrap/service/ScrapService.java
@@ -5,6 +5,7 @@ import com.example.live_backend.domain.board.repository.BoardRepository;
 import com.example.live_backend.domain.memeber.entity.Member;
 import com.example.live_backend.domain.memeber.repository.MemberRepository;
 import com.example.live_backend.domain.scrap.dto.request.ScrapDeleteRequestDto;
+import com.example.live_backend.domain.scrap.dto.response.ScrapDeleteResponseDto;
 import com.example.live_backend.domain.board.dto.response.BoardListResponseDto;
 import com.example.live_backend.global.page.CursorTemplate;
 import com.example.live_backend.domain.scrap.entity.Scrap;
@@ -59,7 +60,7 @@ public class ScrapService {
     }
 
     @Transactional
-    public void removeScraps(Long memberId, ScrapDeleteRequestDto requestDto) {
+    public ScrapDeleteResponseDto removeScraps(Long memberId, ScrapDeleteRequestDto requestDto) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
@@ -68,7 +69,9 @@ public class ScrapService {
             throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
         }
 
-        scrapRepository.deleteByMemberAndBoardIds(member, boardIds);
+        int deletedCount = scrapRepository.deleteByMemberAndBoardIds(member, boardIds);
+        
+        return ScrapDeleteResponseDto.of(boardIds.size(), deletedCount);
     }
 
     public CursorTemplate<Long, BoardListResponseDto> getScrapList(Long memberId, Long cursorId, int size) {

--- a/src/main/java/com/example/live_backend/domain/scrap/service/ScrapService.java
+++ b/src/main/java/com/example/live_backend/domain/scrap/service/ScrapService.java
@@ -1,0 +1,80 @@
+package com.example.live_backend.domain.scrap.service;
+
+import com.example.live_backend.domain.board.entity.Board;
+import com.example.live_backend.domain.board.repository.BoardRepository;
+import com.example.live_backend.domain.memeber.entity.Member;
+import com.example.live_backend.domain.memeber.repository.MemberRepository;
+import com.example.live_backend.domain.scrap.dto.request.ScrapDeleteRequestDto;
+import com.example.live_backend.domain.board.dto.response.BoardListResponseDto;
+import com.example.live_backend.global.page.CursorTemplate;
+import com.example.live_backend.domain.scrap.entity.Scrap;
+import java.util.Optional;
+import com.example.live_backend.domain.scrap.repository.ScrapRepository;
+import com.example.live_backend.global.error.exception.CustomException;
+import com.example.live_backend.global.error.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ScrapService {
+
+    private final ScrapRepository scrapRepository;
+    private final BoardRepository boardRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public boolean toggleScrap(Long memberId, Long boardId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new CustomException(ErrorCode.BOARD_NOT_FOUND));
+
+        if (board.getIsDeleted()) {
+            throw new CustomException(ErrorCode.BOARD_NOT_FOUND);
+        }
+
+        Optional<Scrap> existingScrap = scrapRepository.findByMemberAndBoard(member, board);
+        
+        if (existingScrap.isPresent()) {
+            // 스크랩이 있으면 삭제 (토글 OFF)
+            scrapRepository.delete(existingScrap.get());
+            return false;
+        } else {
+            // 스크랩이 없으면 추가 (토글 ON)
+            Scrap scrap = Scrap.builder()
+                    .member(member)
+                    .board(board)
+                    .build();
+            scrapRepository.save(scrap);
+            return true;
+        }
+    }
+
+    @Transactional
+    public void removeScraps(Long memberId, ScrapDeleteRequestDto requestDto) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        List<Long> boardIds = requestDto.getBoardIds();
+        if (boardIds == null || boardIds.isEmpty()) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        scrapRepository.deleteByMemberAndBoardIds(member, boardIds);
+    }
+
+    public CursorTemplate<Long, BoardListResponseDto> getScrapList(Long memberId, Long cursorId, int size) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        return scrapRepository.findScrapsByMemberWithCursor(member, cursorId, size);
+    }
+
+
+}

--- a/src/main/java/com/example/live_backend/domain/scrap/service/ScrapService.java
+++ b/src/main/java/com/example/live_backend/domain/scrap/service/ScrapService.java
@@ -34,11 +34,9 @@ public class ScrapService {
             throw new CustomException(ErrorCode.MEMBER_NOT_FOUND);
         }
         
-        if (!boardRepository.existsById(boardId)) {
-            throw new CustomException(ErrorCode.BOARD_NOT_FOUND);
-        }
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new CustomException(ErrorCode.BOARD_NOT_FOUND));
         
-        Board board = boardRepository.findById(boardId).get();
         if (board.getIsDeleted()) {
             throw new CustomException(ErrorCode.BOARD_NOT_FOUND);
         }

--- a/src/main/java/com/example/live_backend/domain/scrap/service/ScrapService.java
+++ b/src/main/java/com/example/live_backend/domain/scrap/service/ScrapService.java
@@ -29,24 +29,26 @@ public class ScrapService {
 
     @Transactional
     public boolean toggleScrap(Long memberId, Long boardId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        if (!memberRepository.existsById(memberId)) {
+            throw new CustomException(ErrorCode.MEMBER_NOT_FOUND);
+        }
         
-        Board board = boardRepository.findById(boardId)
-                .orElseThrow(() -> new CustomException(ErrorCode.BOARD_NOT_FOUND));
-
+        if (!boardRepository.existsById(boardId)) {
+            throw new CustomException(ErrorCode.BOARD_NOT_FOUND);
+        }
+        
+        Board board = boardRepository.findById(boardId).get();
         if (board.getIsDeleted()) {
             throw new CustomException(ErrorCode.BOARD_NOT_FOUND);
         }
 
-        Optional<Scrap> existingScrap = scrapRepository.findByMemberAndBoard(member, board);
+        Optional<Scrap> existingScrap = scrapRepository.findByMemberIdAndBoardId(memberId, boardId);
         
         if (existingScrap.isPresent()) {
-            // 스크랩이 있으면 삭제 (토글 OFF)
             scrapRepository.delete(existingScrap.get());
             return false;
         } else {
-            // 스크랩이 없으면 추가 (토글 ON)
+            Member member = memberRepository.getReferenceById(memberId);
             Scrap scrap = Scrap.builder()
                     .member(member)
                     .board(board)

--- a/src/main/java/com/example/live_backend/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/example/live_backend/global/error/exception/ErrorCode.java
@@ -58,6 +58,11 @@ public enum ErrorCode {
 	EXAMPLE_NOT_FOUND(NOT_FOUND, "존재하지 않는 예제입니다."),
 	MISSION_NOT_FOUND(NOT_FOUND, "존재하지 않는 미션입니다."),
 	SURVEY_NOT_FOUND(NOT_FOUND, "존재하지 않는 설문입니다."),
+	SCRAP_NOT_FOUND(NOT_FOUND, "존재하지 않는 스크랩입니다."),
+
+	/* ------------------ 409 CONFLICT : 충돌 오류 ------------------ */
+	SCRAP_ALREADY_EXISTS(CONFLICT, "이미 스크랩한 게시글입니다."),
+	INVALID_INPUT_VALUE(CONFLICT, "잘못된 입력값입니다."),
 
 	/* ------------------ 500 INTERNAL_SERVER_ERROR : 서버 오류 ------------------ */
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),

--- a/src/main/java/com/example/live_backend/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/example/live_backend/global/error/exception/ErrorCode.java
@@ -61,7 +61,6 @@ public enum ErrorCode {
 	SCRAP_NOT_FOUND(NOT_FOUND, "존재하지 않는 스크랩입니다."),
 
 	/* ------------------ 409 CONFLICT : 충돌 오류 ------------------ */
-	SCRAP_ALREADY_EXISTS(CONFLICT, "이미 스크랩한 게시글입니다."),
 	INVALID_INPUT_VALUE(CONFLICT, "잘못된 입력값입니다."),
 
 	/* ------------------ 500 INTERNAL_SERVER_ERROR : 서버 오류 ------------------ */

--- a/src/test/java/com/example/live_backend/domain/board/service/BoardServiceCommentCountTest.java
+++ b/src/test/java/com/example/live_backend/domain/board/service/BoardServiceCommentCountTest.java
@@ -12,6 +12,7 @@ import com.example.live_backend.domain.board.repository.CommentRepository;
 import com.example.live_backend.domain.memeber.entity.Member;
 import com.example.live_backend.domain.memeber.entity.vo.Profile;
 import com.example.live_backend.domain.memeber.repository.MemberRepository;
+import com.example.live_backend.domain.scrap.repository.ScrapRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -54,6 +55,9 @@ class BoardServiceCommentCountTest {
     @Mock
     private CommentRepository commentRepository;
 
+    @Mock
+    private ScrapRepository scrapRepository;
+
     private Board board;
     private Member author;
 
@@ -92,6 +96,7 @@ class BoardServiceCommentCountTest {
         given(boardReactionRepository.countReactionsByBoardId(boardId)).willReturn(List.of());
         given(boardReactionRepository.findActiveReactionsByBoardIdAndMemberId(boardId, memberId)).willReturn(List.of());
         given(commentRepository.countByBoardId(boardId)).willReturn(expectedCommentCount);
+        given(scrapRepository.existsByMemberIdAndBoardId(memberId, boardId)).willReturn(false);
 
         // when
         BoardDetailResponseDto result = boardService.getBoardDetail(boardId, memberId);
@@ -119,6 +124,7 @@ class BoardServiceCommentCountTest {
         given(boardReactionRepository.countReactionsByBoardId(boardId)).willReturn(List.of());
         given(boardReactionRepository.findActiveReactionsByBoardIdAndMemberId(boardId, memberId)).willReturn(List.of());
         given(commentRepository.countByBoardId(boardId)).willReturn(expectedCommentCount);
+        given(scrapRepository.existsByMemberIdAndBoardId(memberId, boardId)).willReturn(false);
 
         // when
         BoardDetailResponseDto result = boardService.getBoardDetail(boardId, memberId);
@@ -140,6 +146,7 @@ class BoardServiceCommentCountTest {
         given(boardReactionRepository.countReactionsByBoardId(boardId)).willReturn(List.of());
         given(boardReactionRepository.findActiveReactionsByBoardIdAndMemberId(boardId, memberId)).willReturn(List.of());
         given(commentRepository.countByBoardId(boardId)).willReturn(5L);
+        given(scrapRepository.existsByMemberIdAndBoardId(memberId, boardId)).willReturn(false);
 
         // when
         BoardDetailResponseDto result = boardService.getBoardDetail(boardId, memberId);

--- a/src/test/java/com/example/live_backend/domain/board/service/BoardServiceTest.java
+++ b/src/test/java/com/example/live_backend/domain/board/service/BoardServiceTest.java
@@ -10,6 +10,7 @@ import com.example.live_backend.domain.board.entity.enums.ReactionType;
 import com.example.live_backend.domain.board.repository.*;
 import com.example.live_backend.domain.memeber.entity.Member;
 import com.example.live_backend.domain.memeber.repository.MemberRepository;
+import com.example.live_backend.domain.scrap.repository.ScrapRepository;
 import com.example.live_backend.global.error.exception.CustomException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -38,7 +39,8 @@ class BoardServiceTest {
 	@Mock private CategoryRepository categoryRepository;
 	@Mock private ImageRepository imageRepository;
 	@Mock private BoardImageRepository boardImageRepository;
-	@Mock private CommentRepository commentRepository; // 누락된 의존성 추가
+	@Mock private CommentRepository commentRepository;
+	@Mock private ScrapRepository scrapRepository;
 
 	@InjectMocks private BoardService boardService;
 
@@ -137,6 +139,8 @@ class BoardServiceTest {
 		when(boardReactionRepository.countReactionsByBoardId(1L)).thenReturn(List.of());
 		when(boardReactionRepository.findActiveReactionsByBoardIdAndMemberId(1L, 1L))
 			.thenReturn(List.of());
+		when(commentRepository.countByBoardId(1L)).thenReturn(0L);
+		when(scrapRepository.existsByMemberIdAndBoardId(1L, 1L)).thenReturn(false);
 
 		BoardDetailResponseDto resp = boardService.getBoardDetail(1L, 1L);
 

--- a/src/test/java/com/example/live_backend/domain/scrap/controller/ScrapControllerTest.java
+++ b/src/test/java/com/example/live_backend/domain/scrap/controller/ScrapControllerTest.java
@@ -4,6 +4,7 @@ import com.example.live_backend.domain.board.dto.response.BoardListResponseDto;
 import com.example.live_backend.domain.scrap.dto.request.ScrapCursorRequestDto;
 import com.example.live_backend.domain.scrap.dto.request.ScrapDeleteRequestDto;
 import com.example.live_backend.domain.scrap.dto.response.ScrapToggleResponseDto;
+import com.example.live_backend.domain.scrap.dto.response.ScrapMessage;
 import com.example.live_backend.domain.scrap.service.ScrapService;
 import com.example.live_backend.global.error.exception.CustomException;
 import com.example.live_backend.global.error.exception.ErrorCode;
@@ -68,7 +69,7 @@ class ScrapControllerTest {
             // then
             assertThat(response.isSuccess()).isTrue();
             assertThat(response.getData().isScraped()).isTrue();
-            assertThat(response.getData().getMessage()).isEqualTo("스크랩이 추가되었습니다.");
+            assertThat(response.getData().getMessage()).isEqualTo(ScrapMessage.SCRAP_ADDED.getMessage());
             verify(scrapService).toggleScrap(TEST_MEMBER_ID, TEST_BOARD_ID);
         }
 
@@ -85,7 +86,7 @@ class ScrapControllerTest {
             // then
             assertThat(response.isSuccess()).isTrue();
             assertThat(response.getData().isScraped()).isFalse();
-            assertThat(response.getData().getMessage()).isEqualTo("스크랩이 취소되었습니다.");
+            assertThat(response.getData().getMessage()).isEqualTo(ScrapMessage.SCRAP_REMOVED.getMessage());
             verify(scrapService).toggleScrap(TEST_MEMBER_ID, TEST_BOARD_ID);
         }
 

--- a/src/test/java/com/example/live_backend/domain/scrap/controller/ScrapControllerTest.java
+++ b/src/test/java/com/example/live_backend/domain/scrap/controller/ScrapControllerTest.java
@@ -1,0 +1,306 @@
+package com.example.live_backend.domain.scrap.controller;
+
+import com.example.live_backend.config.WithMockPrincipalDetails;
+import com.example.live_backend.domain.board.dto.response.BoardListResponseDto;
+import com.example.live_backend.domain.scrap.dto.request.ScrapCursorRequestDto;
+import com.example.live_backend.domain.scrap.dto.request.ScrapDeleteRequestDto;
+import com.example.live_backend.domain.scrap.dto.response.ScrapToggleResponseDto;
+import com.example.live_backend.domain.scrap.service.ScrapService;
+import com.example.live_backend.global.error.exception.CustomException;
+import com.example.live_backend.global.error.exception.ErrorCode;
+import com.example.live_backend.global.page.CursorTemplate;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ScrapController.class)
+@DisplayName("스크랩 컨트롤러 테스트")
+class ScrapControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private ScrapService scrapService;
+
+    @Nested
+    @DisplayName("POST /api/v1/scraps/boards/{boardId}/toggle")
+    class ToggleScrapTest {
+
+        @Test
+        @WithMockPrincipalDetails(memberId = 1L)
+        @DisplayName("스크랩 추가 - 성공")
+        void toggleScrap_AddScrap_Success() throws Exception {
+            // given
+            Long boardId = 1L;
+            given(scrapService.toggleScrap(1L, boardId)).willReturn(true);
+
+            // when & then
+            mockMvc.perform(post("/api/v1/scraps/boards/{boardId}/toggle", boardId)
+                            .with(csrf()))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.isScraped").value(true))
+                    .andExpect(jsonPath("$.data.message").value("스크랩이 추가되었습니다."));
+
+            verify(scrapService).toggleScrap(1L, boardId);
+        }
+
+        @Test
+        @WithMockPrincipalDetails(memberId = 1L)
+        @DisplayName("스크랩 취소 - 성공")
+        void toggleScrap_RemoveScrap_Success() throws Exception {
+            // given
+            Long boardId = 1L;
+            given(scrapService.toggleScrap(1L, boardId)).willReturn(false);
+
+            // when & then
+            mockMvc.perform(post("/api/v1/scraps/boards/{boardId}/toggle", boardId)
+                            .with(csrf()))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.isScraped").value(false))
+                    .andExpect(jsonPath("$.data.message").value("스크랩이 취소되었습니다."));
+
+            verify(scrapService).toggleScrap(1L, boardId);
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 사용자 - 401 에러")
+        void toggleScrap_Unauthorized_Fail() throws Exception {
+            // given
+            Long boardId = 1L;
+
+            // when & then
+            mockMvc.perform(post("/api/v1/scraps/boards/{boardId}/toggle", boardId)
+                            .with(csrf()))
+                    .andDo(print())
+                    .andExpect(status().isUnauthorized());
+
+            verify(scrapService, never()).toggleScrap(anyLong(), anyLong());
+        }
+
+        @Test
+        @WithMockPrincipalDetails(memberId = 1L)
+        @DisplayName("존재하지 않는 게시글 - 404 에러")
+        void toggleScrap_BoardNotFound_Fail() throws Exception {
+            // given
+            Long boardId = 999L;
+            given(scrapService.toggleScrap(1L, boardId))
+                    .willThrow(new CustomException(ErrorCode.BOARD_NOT_FOUND));
+
+            // when & then
+            mockMvc.perform(post("/api/v1/scraps/boards/{boardId}/toggle", boardId)
+                            .with(csrf()))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("BOARD_NOT_FOUND"));
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /api/v1/scraps/boards")
+    class RemoveScrapsTest {
+
+        @Test
+        @WithMockPrincipalDetails(memberId = 1L)
+        @DisplayName("다중 스크랩 삭제 - 성공")
+        void removeScraps_Success() throws Exception {
+            // given
+            ScrapDeleteRequestDto requestDto = new ScrapDeleteRequestDto();
+            List<Long> boardIds = Arrays.asList(1L, 2L, 3L);
+            requestDto.getClass().getDeclaredField("boardIds").setAccessible(true);
+            requestDto.getClass().getDeclaredField("boardIds").set(requestDto, boardIds);
+
+            doNothing().when(scrapService).removeScraps(eq(1L), any(ScrapDeleteRequestDto.class));
+
+            // when & then
+            mockMvc.perform(delete("/api/v1/scraps/boards")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true));
+
+            verify(scrapService).removeScraps(eq(1L), any(ScrapDeleteRequestDto.class));
+        }
+
+        @Test
+        @WithMockPrincipalDetails(memberId = 1L)
+        @DisplayName("빈 배열로 삭제 요청 - 400 에러")
+        void removeScraps_EmptyArray_Fail() throws Exception {
+            // given
+            String requestBody = "{\"boardIds\": []}";
+
+            // when & then
+            mockMvc.perform(delete("/api/v1/scraps/boards")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestBody))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @WithMockPrincipalDetails(memberId = 1L)
+        @DisplayName("100개 초과 삭제 요청 - 400 에러")
+        void removeScraps_ExceedLimit_Fail() throws Exception {
+            // given
+            List<Long> boardIds = new java.util.ArrayList<>();
+            for (long i = 1; i <= 101; i++) {
+                boardIds.add(i);
+            }
+            String requestBody = String.format("{\"boardIds\": %s}", 
+                    objectMapper.writeValueAsString(boardIds));
+
+            // when & then
+            mockMvc.perform(delete("/api/v1/scraps/boards")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestBody))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 사용자 - 401 에러")
+        void removeScraps_Unauthorized_Fail() throws Exception {
+            // given
+            ScrapDeleteRequestDto requestDto = new ScrapDeleteRequestDto();
+            List<Long> boardIds = Arrays.asList(1L, 2L, 3L);
+            requestDto.getClass().getDeclaredField("boardIds").setAccessible(true);
+            requestDto.getClass().getDeclaredField("boardIds").set(requestDto, boardIds);
+
+            // when & then
+            mockMvc.perform(delete("/api/v1/scraps/boards")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isUnauthorized());
+
+            verify(scrapService, never()).removeScraps(anyLong(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/scraps")
+    class GetScrapListTest {
+
+        @Test
+        @WithMockPrincipalDetails(memberId = 1L)
+        @DisplayName("스크랩 목록 조회 - 성공")
+        void getScrapList_Success() throws Exception {
+            // given
+            CursorTemplate<Long, BoardListResponseDto> mockResponse = 
+                    CursorTemplate.of(Collections.emptyList());
+            given(scrapService.getScrapList(1L, null, 20)).willReturn(mockResponse);
+
+            // when & then
+            mockMvc.perform(get("/api/v1/scraps")
+                            .param("size", "20"))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.hasNext").value(false))
+                    .andExpect(jsonPath("$.data.content").isArray());
+
+            verify(scrapService).getScrapList(1L, null, 20);
+        }
+
+        @Test
+        @WithMockPrincipalDetails(memberId = 1L)
+        @DisplayName("커서 ID로 다음 페이지 조회 - 성공")
+        void getScrapList_WithCursor_Success() throws Exception {
+            // given
+            Long cursorId = 10L;
+            CursorTemplate<Long, BoardListResponseDto> mockResponse = 
+                    CursorTemplate.ofWithNextCursor(5L, Collections.emptyList());
+            given(scrapService.getScrapList(1L, cursorId, 20)).willReturn(mockResponse);
+
+            // when & then
+            mockMvc.perform(get("/api/v1/scraps")
+                            .param("cursorId", String.valueOf(cursorId))
+                            .param("size", "20"))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.hasNext").value(true))
+                    .andExpect(jsonPath("$.data.nextCursor").value(5));
+
+            verify(scrapService).getScrapList(1L, cursorId, 20);
+        }
+
+        @Test
+        @WithMockPrincipalDetails(memberId = 1L)
+        @DisplayName("잘못된 size 파라미터 - 400 에러")
+        void getScrapList_InvalidSize_Fail() throws Exception {
+            // when & then
+            mockMvc.perform(get("/api/v1/scraps")
+                            .param("size", "0"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+
+            mockMvc.perform(get("/api/v1/scraps")
+                            .param("size", "101"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+
+            verify(scrapService, never()).getScrapList(anyLong(), any(), anyInt());
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 사용자 - 401 에러")
+        void getScrapList_Unauthorized_Fail() throws Exception {
+            // when & then
+            mockMvc.perform(get("/api/v1/scraps"))
+                    .andDo(print())
+                    .andExpect(status().isUnauthorized());
+
+            verify(scrapService, never()).getScrapList(anyLong(), any(), anyInt());
+        }
+
+        @Test
+        @WithMockPrincipalDetails(memberId = 1L)
+        @DisplayName("회원을 찾을 수 없음 - 404 에러")
+        void getScrapList_MemberNotFound_Fail() throws Exception {
+            // given
+            given(scrapService.getScrapList(1L, null, 20))
+                    .willThrow(new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+            // when & then
+            mockMvc.perform(get("/api/v1/scraps")
+                            .param("size", "20"))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("MEMBER_NOT_FOUND"));
+        }
+    }
+}

--- a/src/test/java/com/example/live_backend/domain/scrap/controller/ScrapControllerTest.java
+++ b/src/test/java/com/example/live_backend/domain/scrap/controller/ScrapControllerTest.java
@@ -1,6 +1,5 @@
 package com.example.live_backend.domain.scrap.controller;
 
-import com.example.live_backend.config.WithMockPrincipalDetails;
 import com.example.live_backend.domain.board.dto.response.BoardListResponseDto;
 import com.example.live_backend.domain.scrap.dto.request.ScrapCursorRequestDto;
 import com.example.live_backend.domain.scrap.dto.request.ScrapDeleteRequestDto;
@@ -8,118 +7,115 @@ import com.example.live_backend.domain.scrap.dto.response.ScrapToggleResponseDto
 import com.example.live_backend.domain.scrap.service.ScrapService;
 import com.example.live_backend.global.error.exception.CustomException;
 import com.example.live_backend.global.error.exception.ErrorCode;
+import com.example.live_backend.global.error.response.ResponseHandler;
 import com.example.live_backend.global.page.CursorTemplate;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.example.live_backend.global.security.PrincipalDetails;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.web.servlet.MockMvc;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@WebMvcTest(ScrapController.class)
-@DisplayName("스크랩 컨트롤러 테스트")
+@ExtendWith(MockitoExtension.class)
+@DisplayName("스크랩 컨트롤러 단위 테스트")
 class ScrapControllerTest {
 
-    @Autowired
-    private MockMvc mockMvc;
-
-    @Autowired
-    private ObjectMapper objectMapper;
-
-    @MockBean
+    @Mock
     private ScrapService scrapService;
+
+    @Mock
+    private PrincipalDetails principalDetails;
+
+    @InjectMocks
+    private ScrapController scrapController;
+
+    private final Long TEST_MEMBER_ID = 1L;
+    private final Long TEST_BOARD_ID = 1L;
+
+    @BeforeEach
+    void setUp() {
+        when(principalDetails.getMemberId()).thenReturn(TEST_MEMBER_ID);
+    }
 
     @Nested
     @DisplayName("POST /api/v1/scraps/boards/{boardId}/toggle")
     class ToggleScrapTest {
 
         @Test
-        @WithMockPrincipalDetails(memberId = 1L)
         @DisplayName("스크랩 추가 - 성공")
-        void toggleScrap_AddScrap_Success() throws Exception {
+        void toggleScrap_AddScrap_Success() {
             // given
-            Long boardId = 1L;
-            given(scrapService.toggleScrap(1L, boardId)).willReturn(true);
+            given(scrapService.toggleScrap(TEST_MEMBER_ID, TEST_BOARD_ID)).willReturn(true);
 
-            // when & then
-            mockMvc.perform(post("/api/v1/scraps/boards/{boardId}/toggle", boardId)
-                            .with(csrf()))
-                    .andDo(print())
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.success").value(true))
-                    .andExpect(jsonPath("$.data.isScraped").value(true))
-                    .andExpect(jsonPath("$.data.message").value("스크랩이 추가되었습니다."));
+            // when
+            ResponseHandler<ScrapToggleResponseDto> response = 
+                    scrapController.toggleScrap(principalDetails, TEST_BOARD_ID);
 
-            verify(scrapService).toggleScrap(1L, boardId);
+            // then
+            assertThat(response.isSuccess()).isTrue();
+            assertThat(response.getData().isScraped()).isTrue();
+            assertThat(response.getData().getMessage()).isEqualTo("스크랩이 추가되었습니다.");
+            verify(scrapService).toggleScrap(TEST_MEMBER_ID, TEST_BOARD_ID);
         }
 
         @Test
-        @WithMockPrincipalDetails(memberId = 1L)
         @DisplayName("스크랩 취소 - 성공")
-        void toggleScrap_RemoveScrap_Success() throws Exception {
+        void toggleScrap_RemoveScrap_Success() {
             // given
-            Long boardId = 1L;
-            given(scrapService.toggleScrap(1L, boardId)).willReturn(false);
+            given(scrapService.toggleScrap(TEST_MEMBER_ID, TEST_BOARD_ID)).willReturn(false);
 
-            // when & then
-            mockMvc.perform(post("/api/v1/scraps/boards/{boardId}/toggle", boardId)
-                            .with(csrf()))
-                    .andDo(print())
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.success").value(true))
-                    .andExpect(jsonPath("$.data.isScraped").value(false))
-                    .andExpect(jsonPath("$.data.message").value("스크랩이 취소되었습니다."));
+            // when
+            ResponseHandler<ScrapToggleResponseDto> response = 
+                    scrapController.toggleScrap(principalDetails, TEST_BOARD_ID);
 
-            verify(scrapService).toggleScrap(1L, boardId);
+            // then
+            assertThat(response.isSuccess()).isTrue();
+            assertThat(response.getData().isScraped()).isFalse();
+            assertThat(response.getData().getMessage()).isEqualTo("스크랩이 취소되었습니다.");
+            verify(scrapService).toggleScrap(TEST_MEMBER_ID, TEST_BOARD_ID);
         }
 
         @Test
-        @DisplayName("인증되지 않은 사용자 - 401 에러")
-        void toggleScrap_Unauthorized_Fail() throws Exception {
+        @DisplayName("존재하지 않는 게시글 - 예외 발생")
+        void toggleScrap_BoardNotFound_ThrowException() {
             // given
-            Long boardId = 1L;
-
-            // when & then
-            mockMvc.perform(post("/api/v1/scraps/boards/{boardId}/toggle", boardId)
-                            .with(csrf()))
-                    .andDo(print())
-                    .andExpect(status().isUnauthorized());
-
-            verify(scrapService, never()).toggleScrap(anyLong(), anyLong());
-        }
-
-        @Test
-        @WithMockPrincipalDetails(memberId = 1L)
-        @DisplayName("존재하지 않는 게시글 - 404 에러")
-        void toggleScrap_BoardNotFound_Fail() throws Exception {
-            // given
-            Long boardId = 999L;
-            given(scrapService.toggleScrap(1L, boardId))
+            Long invalidBoardId = 999L;
+            given(scrapService.toggleScrap(TEST_MEMBER_ID, invalidBoardId))
                     .willThrow(new CustomException(ErrorCode.BOARD_NOT_FOUND));
 
             // when & then
-            mockMvc.perform(post("/api/v1/scraps/boards/{boardId}/toggle", boardId)
-                            .with(csrf()))
-                    .andDo(print())
-                    .andExpect(status().isNotFound())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.error.code").value("BOARD_NOT_FOUND"));
+            assertThrows(CustomException.class, () -> 
+                    scrapController.toggleScrap(principalDetails, invalidBoardId));
+            
+            verify(scrapService).toggleScrap(TEST_MEMBER_ID, invalidBoardId);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 회원 - 예외 발생")
+        void toggleScrap_MemberNotFound_ThrowException() {
+            // given
+            given(scrapService.toggleScrap(TEST_MEMBER_ID, TEST_BOARD_ID))
+                    .willThrow(new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+            // when & then
+            assertThrows(CustomException.class, () -> 
+                    scrapController.toggleScrap(principalDetails, TEST_BOARD_ID));
+            
+            verify(scrapService).toggleScrap(TEST_MEMBER_ID, TEST_BOARD_ID);
         }
     }
 
@@ -128,84 +124,35 @@ class ScrapControllerTest {
     class RemoveScrapsTest {
 
         @Test
-        @WithMockPrincipalDetails(memberId = 1L)
         @DisplayName("다중 스크랩 삭제 - 성공")
-        void removeScraps_Success() throws Exception {
+        void removeScraps_Success() {
             // given
             ScrapDeleteRequestDto requestDto = new ScrapDeleteRequestDto();
             List<Long> boardIds = Arrays.asList(1L, 2L, 3L);
-            requestDto.getClass().getDeclaredField("boardIds").setAccessible(true);
-            requestDto.getClass().getDeclaredField("boardIds").set(requestDto, boardIds);
+            ReflectionTestUtils.setField(requestDto, "boardIds", boardIds);
 
-            doNothing().when(scrapService).removeScraps(eq(1L), any(ScrapDeleteRequestDto.class));
+            // when
+            ResponseHandler<Void> response = scrapController.removeScraps(principalDetails, requestDto);
 
-            // when & then
-            mockMvc.perform(delete("/api/v1/scraps/boards")
-                            .with(csrf())
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(requestDto)))
-                    .andDo(print())
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.success").value(true));
-
-            verify(scrapService).removeScraps(eq(1L), any(ScrapDeleteRequestDto.class));
+            // then
+            assertThat(response.isSuccess()).isTrue();
+            assertThat(response.getData()).isNull();
+            verify(scrapService).removeScraps(eq(TEST_MEMBER_ID), any(ScrapDeleteRequestDto.class));
         }
 
         @Test
-        @WithMockPrincipalDetails(memberId = 1L)
-        @DisplayName("빈 배열로 삭제 요청 - 400 에러")
-        void removeScraps_EmptyArray_Fail() throws Exception {
-            // given
-            String requestBody = "{\"boardIds\": []}";
-
-            // when & then
-            mockMvc.perform(delete("/api/v1/scraps/boards")
-                            .with(csrf())
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(requestBody))
-                    .andDo(print())
-                    .andExpect(status().isBadRequest());
-        }
-
-        @Test
-        @WithMockPrincipalDetails(memberId = 1L)
-        @DisplayName("100개 초과 삭제 요청 - 400 에러")
-        void removeScraps_ExceedLimit_Fail() throws Exception {
-            // given
-            List<Long> boardIds = new java.util.ArrayList<>();
-            for (long i = 1; i <= 101; i++) {
-                boardIds.add(i);
-            }
-            String requestBody = String.format("{\"boardIds\": %s}", 
-                    objectMapper.writeValueAsString(boardIds));
-
-            // when & then
-            mockMvc.perform(delete("/api/v1/scraps/boards")
-                            .with(csrf())
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(requestBody))
-                    .andDo(print())
-                    .andExpect(status().isBadRequest());
-        }
-
-        @Test
-        @DisplayName("인증되지 않은 사용자 - 401 에러")
-        void removeScraps_Unauthorized_Fail() throws Exception {
+        @DisplayName("빈 게시글 ID 목록 - 예외 발생")
+        void removeScraps_EmptyBoardIds_ThrowException() {
             // given
             ScrapDeleteRequestDto requestDto = new ScrapDeleteRequestDto();
-            List<Long> boardIds = Arrays.asList(1L, 2L, 3L);
-            requestDto.getClass().getDeclaredField("boardIds").setAccessible(true);
-            requestDto.getClass().getDeclaredField("boardIds").set(requestDto, boardIds);
+            ReflectionTestUtils.setField(requestDto, "boardIds", Collections.emptyList());
+
+            doThrow(new CustomException(ErrorCode.INVALID_INPUT_VALUE))
+                    .when(scrapService).removeScraps(eq(TEST_MEMBER_ID), any(ScrapDeleteRequestDto.class));
 
             // when & then
-            mockMvc.perform(delete("/api/v1/scraps/boards")
-                            .with(csrf())
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(requestDto)))
-                    .andDo(print())
-                    .andExpect(status().isUnauthorized());
-
-            verify(scrapService, never()).removeScraps(anyLong(), any());
+            assertThrows(CustomException.class, () -> 
+                    scrapController.removeScraps(principalDetails, requestDto));
         }
     }
 
@@ -214,93 +161,66 @@ class ScrapControllerTest {
     class GetScrapListTest {
 
         @Test
-        @WithMockPrincipalDetails(memberId = 1L)
         @DisplayName("스크랩 목록 조회 - 성공")
-        void getScrapList_Success() throws Exception {
+        void getScrapList_Success() {
             // given
+            ScrapCursorRequestDto requestDto = new ScrapCursorRequestDto();
+            requestDto.setCursorId(null);
+            requestDto.setSize(20);
+            
             CursorTemplate<Long, BoardListResponseDto> mockResponse = 
                     CursorTemplate.of(Collections.emptyList());
-            given(scrapService.getScrapList(1L, null, 20)).willReturn(mockResponse);
+            given(scrapService.getScrapList(TEST_MEMBER_ID, null, 20)).willReturn(mockResponse);
 
-            // when & then
-            mockMvc.perform(get("/api/v1/scraps")
-                            .param("size", "20"))
-                    .andDo(print())
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.success").value(true))
-                    .andExpect(jsonPath("$.data.hasNext").value(false))
-                    .andExpect(jsonPath("$.data.content").isArray());
+            // when
+            ResponseHandler<CursorTemplate<Long, BoardListResponseDto>> response = 
+                    scrapController.getScrapList(principalDetails, requestDto);
 
-            verify(scrapService).getScrapList(1L, null, 20);
+            // then
+            assertThat(response.isSuccess()).isTrue();
+            assertThat(response.getData().hasNext()).isFalse();
+            assertThat(response.getData().content()).isEmpty();
+            verify(scrapService).getScrapList(TEST_MEMBER_ID, null, 20);
         }
 
         @Test
-        @WithMockPrincipalDetails(memberId = 1L)
         @DisplayName("커서 ID로 다음 페이지 조회 - 성공")
-        void getScrapList_WithCursor_Success() throws Exception {
+        void getScrapList_WithCursor_Success() {
             // given
-            Long cursorId = 10L;
+            ScrapCursorRequestDto requestDto = new ScrapCursorRequestDto();
+            requestDto.setCursorId(10L);
+            requestDto.setSize(20);
+            
             CursorTemplate<Long, BoardListResponseDto> mockResponse = 
                     CursorTemplate.ofWithNextCursor(5L, Collections.emptyList());
-            given(scrapService.getScrapList(1L, cursorId, 20)).willReturn(mockResponse);
+            given(scrapService.getScrapList(TEST_MEMBER_ID, 10L, 20)).willReturn(mockResponse);
 
-            // when & then
-            mockMvc.perform(get("/api/v1/scraps")
-                            .param("cursorId", String.valueOf(cursorId))
-                            .param("size", "20"))
-                    .andDo(print())
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.success").value(true))
-                    .andExpect(jsonPath("$.data.hasNext").value(true))
-                    .andExpect(jsonPath("$.data.nextCursor").value(5));
+            // when
+            ResponseHandler<CursorTemplate<Long, BoardListResponseDto>> response = 
+                    scrapController.getScrapList(principalDetails, requestDto);
 
-            verify(scrapService).getScrapList(1L, cursorId, 20);
+            // then
+            assertThat(response.isSuccess()).isTrue();
+            assertThat(response.getData().hasNext()).isTrue();
+            assertThat(response.getData().nextCursor()).isEqualTo(5L);
+            verify(scrapService).getScrapList(TEST_MEMBER_ID, 10L, 20);
         }
 
         @Test
-        @WithMockPrincipalDetails(memberId = 1L)
-        @DisplayName("잘못된 size 파라미터 - 400 에러")
-        void getScrapList_InvalidSize_Fail() throws Exception {
-            // when & then
-            mockMvc.perform(get("/api/v1/scraps")
-                            .param("size", "0"))
-                    .andDo(print())
-                    .andExpect(status().isBadRequest());
-
-            mockMvc.perform(get("/api/v1/scraps")
-                            .param("size", "101"))
-                    .andDo(print())
-                    .andExpect(status().isBadRequest());
-
-            verify(scrapService, never()).getScrapList(anyLong(), any(), anyInt());
-        }
-
-        @Test
-        @DisplayName("인증되지 않은 사용자 - 401 에러")
-        void getScrapList_Unauthorized_Fail() throws Exception {
-            // when & then
-            mockMvc.perform(get("/api/v1/scraps"))
-                    .andDo(print())
-                    .andExpect(status().isUnauthorized());
-
-            verify(scrapService, never()).getScrapList(anyLong(), any(), anyInt());
-        }
-
-        @Test
-        @WithMockPrincipalDetails(memberId = 1L)
-        @DisplayName("회원을 찾을 수 없음 - 404 에러")
-        void getScrapList_MemberNotFound_Fail() throws Exception {
+        @DisplayName("회원을 찾을 수 없음 - 예외 발생")
+        void getScrapList_MemberNotFound_ThrowException() {
             // given
-            given(scrapService.getScrapList(1L, null, 20))
+            ScrapCursorRequestDto requestDto = new ScrapCursorRequestDto();
+            requestDto.setSize(20);
+            
+            given(scrapService.getScrapList(TEST_MEMBER_ID, null, 20))
                     .willThrow(new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
             // when & then
-            mockMvc.perform(get("/api/v1/scraps")
-                            .param("size", "20"))
-                    .andDo(print())
-                    .andExpect(status().isNotFound())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.error.code").value("MEMBER_NOT_FOUND"));
+            assertThrows(CustomException.class, () -> 
+                    scrapController.getScrapList(principalDetails, requestDto));
+            
+            verify(scrapService).getScrapList(TEST_MEMBER_ID, null, 20);
         }
     }
 }

--- a/src/test/java/com/example/live_backend/domain/scrap/controller/ScrapControllerTest.java
+++ b/src/test/java/com/example/live_backend/domain/scrap/controller/ScrapControllerTest.java
@@ -3,6 +3,7 @@ package com.example.live_backend.domain.scrap.controller;
 import com.example.live_backend.domain.board.dto.response.BoardListResponseDto;
 import com.example.live_backend.domain.scrap.dto.request.ScrapCursorRequestDto;
 import com.example.live_backend.domain.scrap.dto.request.ScrapDeleteRequestDto;
+import com.example.live_backend.domain.scrap.dto.response.ScrapDeleteResponseDto;
 import com.example.live_backend.domain.scrap.dto.response.ScrapToggleResponseDto;
 import com.example.live_backend.domain.scrap.dto.response.ScrapMessage;
 import com.example.live_backend.domain.scrap.service.ScrapService;
@@ -132,12 +133,16 @@ class ScrapControllerTest {
             List<Long> boardIds = Arrays.asList(1L, 2L, 3L);
             ReflectionTestUtils.setField(requestDto, "boardIds", boardIds);
 
+            given(scrapService.removeScraps(TEST_MEMBER_ID, requestDto))
+                    .willReturn(ScrapDeleteResponseDto.of(3, 3));
+
             // when
-            ResponseHandler<Void> response = scrapController.removeScraps(principalDetails, requestDto);
+            ResponseHandler<ScrapDeleteResponseDto> response = scrapController.removeScraps(principalDetails, requestDto);
 
             // then
             assertThat(response.isSuccess()).isTrue();
-            assertThat(response.getData()).isNull();
+            assertThat(response.getData().getRequestedCount()).isEqualTo(3);
+            assertThat(response.getData().getDeletedCount()).isEqualTo(3);
             verify(scrapService).removeScraps(eq(TEST_MEMBER_ID), any(ScrapDeleteRequestDto.class));
         }
 

--- a/src/test/java/com/example/live_backend/domain/scrap/service/ScrapServiceTest.java
+++ b/src/test/java/com/example/live_backend/domain/scrap/service/ScrapServiceTest.java
@@ -1,0 +1,299 @@
+package com.example.live_backend.domain.scrap.service;
+
+import com.example.live_backend.domain.board.dto.response.BoardListResponseDto;
+import com.example.live_backend.domain.board.entity.Board;
+import com.example.live_backend.domain.board.entity.Category;
+import com.example.live_backend.domain.board.repository.BoardRepository;
+import com.example.live_backend.domain.memeber.entity.Member;
+import com.example.live_backend.domain.memeber.entity.vo.Profile;
+import com.example.live_backend.domain.memeber.repository.MemberRepository;
+import com.example.live_backend.domain.scrap.dto.request.ScrapDeleteRequestDto;
+import com.example.live_backend.domain.scrap.entity.Scrap;
+import com.example.live_backend.domain.scrap.repository.ScrapRepository;
+import com.example.live_backend.global.error.exception.CustomException;
+import com.example.live_backend.global.error.exception.ErrorCode;
+import com.example.live_backend.global.page.CursorTemplate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("스크랩 서비스 테스트")
+class ScrapServiceTest {
+
+    @InjectMocks
+    private ScrapService scrapService;
+
+    @Mock
+    private ScrapRepository scrapRepository;
+
+    @Mock
+    private BoardRepository boardRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    private Member member;
+    private Board board;
+    private Category category;
+    private Scrap scrap;
+
+    @BeforeEach
+    void setUp() {
+        // Member 생성
+        member = Member.builder()
+                .oauthId("test-oauth-id")
+                .email("test@example.com")
+                .profile(Profile.builder()
+                        .nickname("테스트유저")
+                        .profileImageUrl("http://test.com/image.jpg")
+                        .build())
+                .build();
+        ReflectionTestUtils.setField(member, "id", 1L);
+
+        // Category 생성
+        category = new Category();
+        ReflectionTestUtils.setField(category, "id", 1L);
+        ReflectionTestUtils.setField(category, "name", "공지사항");
+
+        // Board 생성
+        board = Board.builder()
+                .title("테스트 게시글")
+                .content("테스트 내용")
+                .category(category)
+                .author(member)
+                .build();
+        ReflectionTestUtils.setField(board, "id", 1L);
+
+        // Scrap 생성
+        scrap = Scrap.builder()
+                .member(member)
+                .board(board)
+                .build();
+        ReflectionTestUtils.setField(scrap, "id", 1L);
+    }
+
+    @Nested
+    @DisplayName("스크랩 토글 기능")
+    class ToggleScrapTest {
+
+        @Test
+        @DisplayName("스크랩이 없는 경우 - 스크랩 추가")
+        void toggleScrap_WhenNotScraped_ShouldAddScrap() {
+            // given
+            given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+            given(boardRepository.findById(1L)).willReturn(Optional.of(board));
+            given(scrapRepository.findByMemberAndBoard(member, board)).willReturn(Optional.empty());
+            given(scrapRepository.save(any(Scrap.class))).willReturn(scrap);
+
+            // when
+            boolean result = scrapService.toggleScrap(1L, 1L);
+
+            // then
+            assertThat(result).isTrue();
+            verify(scrapRepository).save(any(Scrap.class));
+            verify(scrapRepository, never()).delete(any(Scrap.class));
+        }
+
+        @Test
+        @DisplayName("스크랩이 있는 경우 - 스크랩 취소")
+        void toggleScrap_WhenAlreadyScraped_ShouldRemoveScrap() {
+            // given
+            given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+            given(boardRepository.findById(1L)).willReturn(Optional.of(board));
+            given(scrapRepository.findByMemberAndBoard(member, board)).willReturn(Optional.of(scrap));
+
+            // when
+            boolean result = scrapService.toggleScrap(1L, 1L);
+
+            // then
+            assertThat(result).isFalse();
+            verify(scrapRepository).delete(scrap);
+            verify(scrapRepository, never()).save(any(Scrap.class));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 회원 - 예외 발생")
+        void toggleScrap_WhenMemberNotFound_ShouldThrowException() {
+            // given
+            given(memberRepository.findById(1L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> scrapService.toggleScrap(1L, 1L))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
+
+            verify(boardRepository, never()).findById(anyLong());
+            verify(scrapRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 게시글 - 예외 발생")
+        void toggleScrap_WhenBoardNotFound_ShouldThrowException() {
+            // given
+            given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+            given(boardRepository.findById(1L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> scrapService.toggleScrap(1L, 1L))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.BOARD_NOT_FOUND);
+
+            verify(scrapRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("삭제된 게시글 - 예외 발생")
+        void toggleScrap_WhenBoardIsDeleted_ShouldThrowException() {
+            // given
+            board.delete();
+            given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+            given(boardRepository.findById(1L)).willReturn(Optional.of(board));
+
+            // when & then
+            assertThatThrownBy(() -> scrapService.toggleScrap(1L, 1L))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.BOARD_NOT_FOUND);
+
+            verify(scrapRepository, never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("다중 스크랩 삭제 기능")
+    class RemoveScrapsTest {
+
+        @Test
+        @DisplayName("정상적으로 다중 스크랩 삭제")
+        void removeScraps_Success() {
+            // given
+            ScrapDeleteRequestDto requestDto = new ScrapDeleteRequestDto();
+            List<Long> boardIds = Arrays.asList(1L, 2L, 3L);
+            ReflectionTestUtils.setField(requestDto, "boardIds", boardIds);
+
+            given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+
+            // when
+            scrapService.removeScraps(1L, requestDto);
+
+            // then
+            verify(scrapRepository).deleteByMemberAndBoardIds(member, boardIds);
+        }
+
+        @Test
+        @DisplayName("빈 게시글 ID 목록 - 예외 발생")
+        void removeScraps_WhenEmptyBoardIds_ShouldThrowException() {
+            // given
+            ScrapDeleteRequestDto requestDto = new ScrapDeleteRequestDto();
+            ReflectionTestUtils.setField(requestDto, "boardIds", List.of());
+
+            given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+
+            // when & then
+            assertThatThrownBy(() -> scrapService.removeScraps(1L, requestDto))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT_VALUE);
+
+            verify(scrapRepository, never()).deleteByMemberAndBoardIds(any(), any());
+        }
+
+        @Test
+        @DisplayName("null 게시글 ID 목록 - 예외 발생")
+        void removeScraps_WhenNullBoardIds_ShouldThrowException() {
+            // given
+            ScrapDeleteRequestDto requestDto = new ScrapDeleteRequestDto();
+            ReflectionTestUtils.setField(requestDto, "boardIds", null);
+
+            given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+
+            // when & then
+            assertThatThrownBy(() -> scrapService.removeScraps(1L, requestDto))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT_VALUE);
+
+            verify(scrapRepository, never()).deleteByMemberAndBoardIds(any(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("스크랩 목록 조회 기능")
+    class GetScrapListTest {
+
+        @Test
+        @DisplayName("정상적으로 스크랩 목록 조회")
+        void getScrapList_Success() {
+            // given
+            Long cursorId = null;
+            int size = 20;
+            
+            CursorTemplate<Long, BoardListResponseDto> mockResponse = CursorTemplate.of(List.of());
+            
+            given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+            given(scrapRepository.findScrapsByMemberWithCursor(member, cursorId, size))
+                    .willReturn(mockResponse);
+
+            // when
+            CursorTemplate<Long, BoardListResponseDto> result = 
+                    scrapService.getScrapList(1L, cursorId, size);
+
+            // then
+            assertThat(result).isEqualTo(mockResponse);
+            verify(scrapRepository).findScrapsByMemberWithCursor(member, cursorId, size);
+        }
+
+        @Test
+        @DisplayName("커서 ID가 있는 경우 스크랩 목록 조회")
+        void getScrapList_WithCursorId_Success() {
+            // given
+            Long cursorId = 10L;
+            int size = 20;
+            
+            CursorTemplate<Long, BoardListResponseDto> mockResponse = 
+                    CursorTemplate.ofWithNextCursor(5L, List.of());
+            
+            given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+            given(scrapRepository.findScrapsByMemberWithCursor(member, cursorId, size))
+                    .willReturn(mockResponse);
+
+            // when
+            CursorTemplate<Long, BoardListResponseDto> result = 
+                    scrapService.getScrapList(1L, cursorId, size);
+
+            // then
+            assertThat(result).isEqualTo(mockResponse);
+            assertThat(result.hasNext()).isTrue();
+            assertThat(result.nextCursor()).isEqualTo(5L);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 회원 - 예외 발생")
+        void getScrapList_WhenMemberNotFound_ShouldThrowException() {
+            // given
+            given(memberRepository.findById(1L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> scrapService.getScrapList(1L, null, 20))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
+
+            verify(scrapRepository, never()).findScrapsByMemberWithCursor(any(), any(), anyInt());
+        }
+    }
+}

--- a/src/test/java/com/example/live_backend/domain/scrap/service/ScrapServiceTest.java
+++ b/src/test/java/com/example/live_backend/domain/scrap/service/ScrapServiceTest.java
@@ -57,7 +57,6 @@ class ScrapServiceTest {
 
     @BeforeEach
     void setUp() {
-        // Member 생성
         member = Member.builder()
                 .oauthId("test-oauth-id")
                 .email("test@example.com")
@@ -68,13 +67,11 @@ class ScrapServiceTest {
                 .build();
         ReflectionTestUtils.setField(member, "id", 1L);
 
-        // Category 생성
         category = Category.builder()
                 .name("공지사항")
                 .build();
         ReflectionTestUtils.setField(category, "id", 1L);
 
-        // Board 생성
         board = Board.builder()
                 .title("테스트 게시글")
                 .content("테스트 내용")
@@ -83,7 +80,6 @@ class ScrapServiceTest {
                 .build();
         ReflectionTestUtils.setField(board, "id", 1L);
 
-        // Scrap 생성
         scrap = Scrap.builder()
                 .member(member)
                 .board(board)

--- a/src/test/java/com/example/live_backend/domain/scrap/service/ScrapServiceTest.java
+++ b/src/test/java/com/example/live_backend/domain/scrap/service/ScrapServiceTest.java
@@ -69,9 +69,10 @@ class ScrapServiceTest {
         ReflectionTestUtils.setField(member, "id", 1L);
 
         // Category 생성
-        category = new Category();
+        category = Category.builder()
+                .name("공지사항")
+                .build();
         ReflectionTestUtils.setField(category, "id", 1L);
-        ReflectionTestUtils.setField(category, "name", "공지사항");
 
         // Board 생성
         board = Board.builder()

--- a/src/test/java/com/example/live_backend/domain/scrap/service/ScrapServiceTest.java
+++ b/src/test/java/com/example/live_backend/domain/scrap/service/ScrapServiceTest.java
@@ -97,7 +97,6 @@ class ScrapServiceTest {
         void toggleScrap_WhenNotScraped_ShouldAddScrap() {
             // given
             given(memberRepository.existsById(1L)).willReturn(true);
-            given(boardRepository.existsById(1L)).willReturn(true);
             given(boardRepository.findById(1L)).willReturn(Optional.of(board));
             given(scrapRepository.findByMemberIdAndBoardId(1L, 1L)).willReturn(Optional.empty());
             given(memberRepository.getReferenceById(1L)).willReturn(member);
@@ -117,7 +116,6 @@ class ScrapServiceTest {
         void toggleScrap_WhenAlreadyScraped_ShouldRemoveScrap() {
             // given
             given(memberRepository.existsById(1L)).willReturn(true);
-            given(boardRepository.existsById(1L)).willReturn(true);
             given(boardRepository.findById(1L)).willReturn(Optional.of(board));
             given(scrapRepository.findByMemberIdAndBoardId(1L, 1L)).willReturn(Optional.of(scrap));
 
@@ -141,7 +139,7 @@ class ScrapServiceTest {
                     .isInstanceOf(CustomException.class)
                     .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
 
-            verify(boardRepository, never()).existsById(anyLong());
+            verify(boardRepository, never()).findById(anyLong());
             verify(scrapRepository, never()).save(any());
         }
 
@@ -150,7 +148,7 @@ class ScrapServiceTest {
         void toggleScrap_WhenBoardNotFound_ShouldThrowException() {
             // given
             given(memberRepository.existsById(1L)).willReturn(true);
-            given(boardRepository.existsById(1L)).willReturn(false);
+            given(boardRepository.findById(1L)).willReturn(Optional.empty());
 
             // when & then
             assertThatThrownBy(() -> scrapService.toggleScrap(1L, 1L))
@@ -166,7 +164,6 @@ class ScrapServiceTest {
             // given
             board.delete();
             given(memberRepository.existsById(1L)).willReturn(true);
-            given(boardRepository.existsById(1L)).willReturn(true);
             given(boardRepository.findById(1L)).willReturn(Optional.of(board));
 
             // when & then

--- a/src/test/java/com/example/live_backend/domain/scrap/service/ScrapServiceTest.java
+++ b/src/test/java/com/example/live_backend/domain/scrap/service/ScrapServiceTest.java
@@ -8,6 +8,7 @@ import com.example.live_backend.domain.memeber.entity.Member;
 import com.example.live_backend.domain.memeber.entity.vo.Profile;
 import com.example.live_backend.domain.memeber.repository.MemberRepository;
 import com.example.live_backend.domain.scrap.dto.request.ScrapDeleteRequestDto;
+import com.example.live_backend.domain.scrap.dto.response.ScrapDeleteResponseDto;
 import com.example.live_backend.domain.scrap.entity.Scrap;
 import com.example.live_backend.domain.scrap.repository.ScrapRepository;
 import com.example.live_backend.global.error.exception.CustomException;
@@ -190,11 +191,14 @@ class ScrapServiceTest {
             ReflectionTestUtils.setField(requestDto, "boardIds", boardIds);
 
             given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+            given(scrapRepository.deleteByMemberAndBoardIds(member, boardIds)).willReturn(3);
 
             // when
-            scrapService.removeScraps(1L, requestDto);
+            ScrapDeleteResponseDto result = scrapService.removeScraps(1L, requestDto);
 
             // then
+            assertThat(result.getRequestedCount()).isEqualTo(3);
+            assertThat(result.getDeletedCount()).isEqualTo(3);
             verify(scrapRepository).deleteByMemberAndBoardIds(member, boardIds);
         }
 
@@ -230,6 +234,46 @@ class ScrapServiceTest {
                     .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT_VALUE);
 
             verify(scrapRepository, never()).deleteByMemberAndBoardIds(any(), any());
+        }
+
+        @Test
+        @DisplayName("일부만 삭제된 경우 - 삭제된 개수 반환")
+        void removeScraps_WhenPartiallyDeleted_ShouldReturnDeletedCount() {
+            // given
+            ScrapDeleteRequestDto requestDto = new ScrapDeleteRequestDto();
+            List<Long> boardIds = Arrays.asList(1L, 2L, 3L, 4L, 5L);
+            ReflectionTestUtils.setField(requestDto, "boardIds", boardIds);
+
+            given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+            given(scrapRepository.deleteByMemberAndBoardIds(member, boardIds)).willReturn(2); // 5개 중 2개만 삭제
+
+            // when
+            ScrapDeleteResponseDto result = scrapService.removeScraps(1L, requestDto);
+
+            // then
+            assertThat(result.getRequestedCount()).isEqualTo(5);
+            assertThat(result.getDeletedCount()).isEqualTo(2);
+            verify(scrapRepository).deleteByMemberAndBoardIds(member, boardIds);
+        }
+
+        @Test
+        @DisplayName("아무것도 삭제되지 않은 경우 - 0 반환")
+        void removeScraps_WhenNothingDeleted_ShouldReturnZero() {
+            // given
+            ScrapDeleteRequestDto requestDto = new ScrapDeleteRequestDto();
+            List<Long> boardIds = Arrays.asList(1L, 2L, 3L);
+            ReflectionTestUtils.setField(requestDto, "boardIds", boardIds);
+
+            given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+            given(scrapRepository.deleteByMemberAndBoardIds(member, boardIds)).willReturn(0); // 아무것도 삭제되지 않음
+
+            // when
+            ScrapDeleteResponseDto result = scrapService.removeScraps(1L, requestDto);
+
+            // then
+            assertThat(result.getRequestedCount()).isEqualTo(3);
+            assertThat(result.getDeletedCount()).isEqualTo(0);
+            verify(scrapRepository).deleteByMemberAndBoardIds(member, boardIds);
         }
     }
 

--- a/src/test/java/com/example/live_backend/domain/scrap/service/ScrapServiceTest.java
+++ b/src/test/java/com/example/live_backend/domain/scrap/service/ScrapServiceTest.java
@@ -95,9 +95,11 @@ class ScrapServiceTest {
         @DisplayName("스크랩이 없는 경우 - 스크랩 추가")
         void toggleScrap_WhenNotScraped_ShouldAddScrap() {
             // given
-            given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+            given(memberRepository.existsById(1L)).willReturn(true);
+            given(boardRepository.existsById(1L)).willReturn(true);
             given(boardRepository.findById(1L)).willReturn(Optional.of(board));
-            given(scrapRepository.findByMemberAndBoard(member, board)).willReturn(Optional.empty());
+            given(scrapRepository.findByMemberIdAndBoardId(1L, 1L)).willReturn(Optional.empty());
+            given(memberRepository.getReferenceById(1L)).willReturn(member);
             given(scrapRepository.save(any(Scrap.class))).willReturn(scrap);
 
             // when
@@ -113,9 +115,10 @@ class ScrapServiceTest {
         @DisplayName("스크랩이 있는 경우 - 스크랩 취소")
         void toggleScrap_WhenAlreadyScraped_ShouldRemoveScrap() {
             // given
-            given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+            given(memberRepository.existsById(1L)).willReturn(true);
+            given(boardRepository.existsById(1L)).willReturn(true);
             given(boardRepository.findById(1L)).willReturn(Optional.of(board));
-            given(scrapRepository.findByMemberAndBoard(member, board)).willReturn(Optional.of(scrap));
+            given(scrapRepository.findByMemberIdAndBoardId(1L, 1L)).willReturn(Optional.of(scrap));
 
             // when
             boolean result = scrapService.toggleScrap(1L, 1L);
@@ -130,14 +133,14 @@ class ScrapServiceTest {
         @DisplayName("존재하지 않는 회원 - 예외 발생")
         void toggleScrap_WhenMemberNotFound_ShouldThrowException() {
             // given
-            given(memberRepository.findById(1L)).willReturn(Optional.empty());
+            given(memberRepository.existsById(1L)).willReturn(false);
 
             // when & then
             assertThatThrownBy(() -> scrapService.toggleScrap(1L, 1L))
                     .isInstanceOf(CustomException.class)
                     .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
 
-            verify(boardRepository, never()).findById(anyLong());
+            verify(boardRepository, never()).existsById(anyLong());
             verify(scrapRepository, never()).save(any());
         }
 
@@ -145,8 +148,8 @@ class ScrapServiceTest {
         @DisplayName("존재하지 않는 게시글 - 예외 발생")
         void toggleScrap_WhenBoardNotFound_ShouldThrowException() {
             // given
-            given(memberRepository.findById(1L)).willReturn(Optional.of(member));
-            given(boardRepository.findById(1L)).willReturn(Optional.empty());
+            given(memberRepository.existsById(1L)).willReturn(true);
+            given(boardRepository.existsById(1L)).willReturn(false);
 
             // when & then
             assertThatThrownBy(() -> scrapService.toggleScrap(1L, 1L))
@@ -161,7 +164,8 @@ class ScrapServiceTest {
         void toggleScrap_WhenBoardIsDeleted_ShouldThrowException() {
             // given
             board.delete();
-            given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+            given(memberRepository.existsById(1L)).willReturn(true);
+            given(boardRepository.existsById(1L)).willReturn(true);
             given(boardRepository.findById(1L)).willReturn(Optional.of(board));
 
             // when & then


### PR DESCRIPTION
  ### ✅ PR 타입 (하나 이상 선택해주세요)

  - [x]  기능 추가
  - [ ]  기능 삭제
  - [ ]  리팩토링 / 코드 개선
  - [ ]  의존성 / 환경 설정 변경
  - [ ]  버그 수정
  - [ ]  기타 (하단에 설명)

  &nbsp;
  ### ✨ 어떤 내용인가요?

  > 게시글 스크랩(북마크) 기능을 추가하여 사용자가 관심있는 게시글을 저장하고 조회할 수 있도록 구현했습니다.
  >

  &nbsp;
  ### 🔍 작업 상세 내용

  - [x]  스크랩 엔티티 및 리포지토리 구현
      - Scrap 엔티티 생성 
      - ScrapRepository 인터페이스 구현
      - 중복 스크랩 방지를 위한 유니크 제약조건 추가
  - [x]  스크랩 서비스 로직 구현
      - 스크랩 토글 기능 (추가/삭제)
      - 내 스크랩 목록 조회
      - N+1 문제 해결을 위한 fetch join 적용
  - [x]  스크랩 컨트롤러 및 API 엔드포인트 구현
      - POST /api/boards/{boardId}/scrap (스크랩 토글)
      - GET /api/scraps (내 스크랩 목록 조회)
  - [x]  게시글 상세 조회 시 스크랩 여부 표시
      - 조회 시 현재 사용자의 스크랩 여부 확인
  - [x]  테스트 코드 작성
      - 스크랩 서비스 단위 테스트
      - 스크랩 컨트롤러 통합 테스트
      - 기존 BoardService 테스트 수정 (ScrapRepository 의존성 추가)

  &nbsp;
  ### 💬 리뷰어에게 전달할 내용 (선택)


  &nbsp;
  ### 🔗 관련 이슈 (선택)

  - Resolves: #이슈번호
  - Ref: #참고이슈
  - Related to: #연관이슈
