### PR TITLE
[Feat/#86] 위치 기반 방문 미션 추천 기능

### DIFF
--- a/src/main/java/com/example/live_backend/domain/mission/clover/controller/CloverMissionController.java
+++ b/src/main/java/com/example/live_backend/domain/mission/clover/controller/CloverMissionController.java
@@ -13,6 +13,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.math.BigDecimal;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/missions/clover")
@@ -25,10 +27,12 @@ public class CloverMissionController implements CloverMissionControllerDocs {
 	@GetMapping
 	@AuthenticatedApi(reason = "클로버 미션 리스트 조회는 로그인한 사용자만 가능합니다")
 	public ResponseHandler<CloverMissionListResponseDto> getCloverMissionList(
+			@RequestParam("lat") BigDecimal lat,
+			@RequestParam("lon") BigDecimal lon,
 			@AuthenticationPrincipal PrincipalDetails userDetails) {
 
 		Long userId = userDetails.getMemberId();
-		CloverMissionListResponseDto response = cloverMissionService.getCloverMissionList(userId);
+		CloverMissionListResponseDto response = cloverMissionService.getCloverMissionList(userId, lat, lon);
 
 		return ResponseHandler.success(response);
 	}
@@ -90,10 +94,12 @@ public class CloverMissionController implements CloverMissionControllerDocs {
 	@GetMapping("/refill")
 	@AuthenticatedApi(reason = "클로버 미션 리필은 로그인한 사용자만 가능합니다")
 	public ResponseHandler<CloverMissionListResponseDto> refillCloverMission(
+			@RequestParam("lat") BigDecimal lat,
+			@RequestParam("lon") BigDecimal lon,
 			@AuthenticationPrincipal PrincipalDetails userDetails) {
 
 		Long userId = userDetails.getMemberId();
-		CloverMissionListResponseDto response = cloverMissionService.assignCloverMissionList(userId);
+		CloverMissionListResponseDto response = cloverMissionService.assignCloverMissionList(userId, lat, lon);
 
 		return ResponseHandler.success(response);
 	}

--- a/src/main/java/com/example/live_backend/domain/mission/clover/controller/docs/CloverMissionControllerDocs.java
+++ b/src/main/java/com/example/live_backend/domain/mission/clover/controller/docs/CloverMissionControllerDocs.java
@@ -10,12 +10,17 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.math.BigDecimal;
 
 @Tag(name = "Clover Mission", description = "클로버 미션 관련 API")
 public interface CloverMissionControllerDocs {
 
     @Operation(summary = "클로버 미션 리스트 조회 ", description = "클로버 미션 리스트를 조회합니다.")
     ResponseHandler<CloverMissionListResponseDto> getCloverMissionList(
+            @Parameter(description = "사용자 현재 위도") @RequestParam("lat") BigDecimal lat,
+            @Parameter(description = "사용자 현재 경도") @RequestParam("lon") BigDecimal lon,
             @Parameter(hidden = true)
             @AuthenticationPrincipal PrincipalDetails userDetails
     );
@@ -50,6 +55,8 @@ public interface CloverMissionControllerDocs {
 
     @Operation(summary = "클로버 리필", description = "클로버 미션을 새롭게 할당합니다.")
     ResponseHandler<CloverMissionListResponseDto> refillCloverMission(
+            @Parameter(description = "사용자 현재 위도") @RequestParam("lat") BigDecimal lat,
+            @Parameter(description = "사용자 현재 경도") @RequestParam("lon") BigDecimal lon,
             @Parameter(hidden = true)
             @AuthenticationPrincipal PrincipalDetails userDetails
     );

--- a/src/main/java/com/example/live_backend/domain/mission/clover/dto/AdminRegisterCloverMissionRequestDto.java
+++ b/src/main/java/com/example/live_backend/domain/mission/clover/dto/AdminRegisterCloverMissionRequestDto.java
@@ -22,7 +22,7 @@ public class AdminRegisterCloverMissionRequestDto {
     private int requiredMeters;
     private int requiredSeconds;
     private String illustrationUrl;
-    private String targetAddress;
+    private String targetPlaceCategory;
 
     private String relatedFeature;
     private String activityDescription;

--- a/src/main/java/com/example/live_backend/domain/mission/clover/dto/CloverMissionListResponseDto.java
+++ b/src/main/java/com/example/live_backend/domain/mission/clover/dto/CloverMissionListResponseDto.java
@@ -57,14 +57,20 @@ public class CloverMissionListResponseDto {
      */
     public static CloverMissionListResponseDto of(Long userId, List<CloverMissionRecord> missionRecords) {
         List<CloverMissionList> missionDtoList = missionRecords.stream()
-                .map(record -> CloverMissionList.builder()
-                        .userMissionId(record.getId())
-                        .missionTitle(record.getMissionTitle())
-                        .cloverType(record.getCloverType())
-                        .missionStatus(record.getCloverMissionStatus())
-                        .missionDifficulty(record.getMissionDifficulty())
-                        .missionCategory(record.getMissionCategory())
-                        .build())
+                .map(record -> {
+                    String missionTitle = record.getMissionTitle();
+                    if (record.getCloverType() == CloverType.VISIT && record.getPlaceName() != null && !record.getPlaceName().isEmpty()) {
+                        missionTitle = String.format("%s (%s)", record.getMissionTitle(), record.getPlaceName());
+                    }
+                    return CloverMissionList.builder()
+                            .userMissionId(record.getId())
+                            .missionTitle(missionTitle)
+                            .cloverType(record.getCloverType())
+                            .missionStatus(record.getCloverMissionStatus())
+                            .missionDifficulty(record.getMissionDifficulty())
+                            .missionCategory(record.getMissionCategory())
+                            .build();
+                })
                 .toList();
 
         return CloverMissionListResponseDto.builder()

--- a/src/main/java/com/example/live_backend/domain/mission/clover/dto/CloverMissionResponseDto.java
+++ b/src/main/java/com/example/live_backend/domain/mission/clover/dto/CloverMissionResponseDto.java
@@ -45,8 +45,17 @@ public class CloverMissionResponseDto {
     @Schema(description = "거리 미션 남은 거리", example = "500")
     private Integer remainingDistance;
 
-    @Schema(description = "방문 미션 주소", example = "주소정보")
-    private String targetAddress;
+    @Schema(description = "추천 장소 이름", example = "스타벅스 OO점")
+    private String placeName;
+
+    @Schema(description = "추천 장소 주소", example = "서울시 강남구 ...")
+    private String address;
+
+    @Schema(description = "추천 장소 위도", example = "37.123456")
+    private String latitude;
+
+    @Schema(description = "추천 장소 경도", example = "127.123456")
+    private String longitude;
 
     @Schema(description = "일러스트레이션 주소", example = "S3 URL")
     private String illustrationUrl;
@@ -96,7 +105,10 @@ public class CloverMissionResponseDto {
     }
 
     private static void addVisitInfo(CloverMissionResponseDto.CloverMissionResponseDtoBuilder builder, CloverMissionRecord missionRecord) {
-        builder.targetAddress(missionRecord.getTargetAddress());
+        builder.placeName(missionRecord.getPlaceName())
+                .address(missionRecord.getAddress())
+                .latitude(missionRecord.getLatitude())
+                .longitude(missionRecord.getLongitude());
     }
 
     private static void addPhotoInfo(CloverMissionResponseDto.CloverMissionResponseDtoBuilder builder, CloverMissionRecord missionRecord) {

--- a/src/main/java/com/example/live_backend/domain/mission/clover/dto/CloverMissionResponseDto.java
+++ b/src/main/java/com/example/live_backend/domain/mission/clover/dto/CloverMissionResponseDto.java
@@ -1,6 +1,7 @@
 package com.example.live_backend.domain.mission.clover.dto;
 
 import com.example.live_backend.domain.mission.clover.Enum.CloverMissionStatus;
+import com.example.live_backend.domain.mission.clover.Enum.CloverType;
 import com.example.live_backend.domain.mission.clover.Enum.MissionCategory;
 import com.example.live_backend.domain.mission.clover.Enum.MissionDifficulty;
 import com.example.live_backend.domain.mission.clover.entity.CloverMissionRecord;
@@ -61,10 +62,16 @@ public class CloverMissionResponseDto {
     private String illustrationUrl;
 
     public static CloverMissionResponseDto from(CloverMissionRecord missionRecord) {
+
+        String missionTitle = missionRecord.getMissionTitle();
+        if (missionRecord.getCloverType() == CloverType.VISIT && missionRecord.getPlaceName() != null && !missionRecord.getPlaceName().isEmpty()) {
+            missionTitle = String.format("%s (%s)", missionRecord.getMissionTitle(), missionRecord.getPlaceName());
+        }
+
         CloverMissionResponseDto.CloverMissionResponseDtoBuilder builder = CloverMissionResponseDto.builder()
                 .userMissionId(missionRecord.getId())
                 .cloverType(String.valueOf(missionRecord.getCloverType()))
-                .missionTitle(missionRecord.getMissionTitle())
+                .missionTitle(missionTitle)
                 .missionStatus(missionRecord.getCloverMissionStatus())
                 .missionDifficulty(missionRecord.getMissionDifficulty())
                 .missionCategory(missionRecord.getMissionCategory());

--- a/src/main/java/com/example/live_backend/domain/mission/clover/dto/CloverMissionResponseDto.java
+++ b/src/main/java/com/example/live_backend/domain/mission/clover/dto/CloverMissionResponseDto.java
@@ -46,16 +46,16 @@ public class CloverMissionResponseDto {
     @Schema(description = "거리 미션 남은 거리", example = "500")
     private Integer remainingDistance;
 
-    @Schema(description = "추천 장소 이름", example = "스타벅스 OO점")
+    @Schema(description = "방문 미션 장소 이름", example = "스타벅스 OO점")
     private String placeName;
 
-    @Schema(description = "추천 장소 주소", example = "서울시 강남구 ...")
+    @Schema(description = "방문 미션 장소 주소", example = "서울시 강남구 ...")
     private String address;
 
-    @Schema(description = "추천 장소 위도", example = "37.123456")
+    @Schema(description = "방문 미션 장소 위도", example = "37.123456")
     private String latitude;
 
-    @Schema(description = "추천 장소 경도", example = "127.123456")
+    @Schema(description = "방문 미션 장소 경도", example = "127.123456")
     private String longitude;
 
     @Schema(description = "일러스트레이션 주소", example = "S3 URL")

--- a/src/main/java/com/example/live_backend/domain/mission/clover/entity/CloverMission.java
+++ b/src/main/java/com/example/live_backend/domain/mission/clover/entity/CloverMission.java
@@ -61,7 +61,7 @@ public abstract class CloverMission extends BaseEntity {
         } else if (cloverType.equals(CloverType.PHOTO)) {
             mission = new PhotoMission(dto.getIllustrationUrl());
         } else if (cloverType.equals(CloverType.VISIT)) {
-            mission = new VisitMission(dto.getTargetAddress());
+            mission = new VisitMission(dto.getTargetPlaceCategory());
         } else {
             throw new CustomException(ErrorCode.INVALID_CLOVER_TYPE);
         }

--- a/src/main/java/com/example/live_backend/domain/mission/clover/entity/CloverMissionRecord.java
+++ b/src/main/java/com/example/live_backend/domain/mission/clover/entity/CloverMissionRecord.java
@@ -69,6 +69,18 @@ public class CloverMissionRecord {
     @Column(name = "target_address")
     private String targetAddress;
 
+    @Column(name = "place_name")
+    private String placeName;
+
+    @Column(name = "address")
+    private String address;
+
+    @Column(name = "latitude")
+    private String latitude;
+
+    @Column(name = "longitude")
+    private String longitude;
+
     @Column(name = "illustration_url")
     private String illustrationUrl;
 
@@ -115,6 +127,13 @@ public class CloverMissionRecord {
         }
 
         return builder.build();
+    }
+
+    public void setVisitPlace(String placeName, String address, String latitude, String longitude) {
+        this.placeName = placeName;
+        this.address = address;
+        this.latitude = latitude;
+        this.longitude = longitude;
     }
 
     public void updateDistanceProgress(int progressInMeters) {

--- a/src/main/java/com/example/live_backend/domain/mission/clover/entity/CloverMissionRecord.java
+++ b/src/main/java/com/example/live_backend/domain/mission/clover/entity/CloverMissionRecord.java
@@ -66,8 +66,8 @@ public class CloverMissionRecord {
     @Column(name = "progress_in_seconds")
     private Integer progressInSeconds;
 
-    @Column(name = "target_address")
-    private String targetAddress;
+    @Column(name = "target_place_category")
+    private String targetPlaceCategory;
 
     @Column(name = "place_name")
     private String placeName;
@@ -127,13 +127,6 @@ public class CloverMissionRecord {
         }
 
         return builder.build();
-    }
-
-    public void setVisitPlace(String placeName, String address, String latitude, String longitude) {
-        this.placeName = placeName;
-        this.address = address;
-        this.latitude = latitude;
-        this.longitude = longitude;
     }
 
     public void updateDistanceProgress(int progressInMeters) {
@@ -202,6 +195,13 @@ public class CloverMissionRecord {
         if (imageUrl != null) {
             this.imageUrl = imageUrl;
         }
+    }
+
+    public void setVisitPlace(String placeName, String address, String latitude, String longitude) {
+        this.placeName = placeName;
+        this.address = address;
+        this.latitude = latitude;
+        this.longitude = longitude;
     }
 }
 

--- a/src/main/java/com/example/live_backend/domain/mission/clover/entity/CloverMissionRecord.java
+++ b/src/main/java/com/example/live_backend/domain/mission/clover/entity/CloverMissionRecord.java
@@ -66,9 +66,6 @@ public class CloverMissionRecord {
     @Column(name = "progress_in_seconds")
     private Integer progressInSeconds;
 
-    @Column(name = "target_place_category")
-    private String targetPlaceCategory;
-
     @Column(name = "place_name")
     private String placeName;
 

--- a/src/main/java/com/example/live_backend/domain/mission/clover/entity/VisitMission.java
+++ b/src/main/java/com/example/live_backend/domain/mission/clover/entity/VisitMission.java
@@ -12,10 +12,10 @@ import lombok.NoArgsConstructor;
 public class VisitMission extends CloverMission {
 
     @Column(name = "target_address")
-    private String targetAddress;
+    private String targetPlaceCategory;
 
     public VisitMission(String targetAddress) {
-        this.targetAddress = targetAddress;
+        this.targetPlaceCategory = targetAddress;
     }
 
     @Override

--- a/src/main/java/com/example/live_backend/domain/mission/clover/entity/VisitMission.java
+++ b/src/main/java/com/example/live_backend/domain/mission/clover/entity/VisitMission.java
@@ -11,11 +11,11 @@ import lombok.NoArgsConstructor;
 @Getter
 public class VisitMission extends CloverMission {
 
-    @Column(name = "target_address")
+    @Column(name = "target_place_category")
     private String targetPlaceCategory;
 
-    public VisitMission(String targetAddress) {
-        this.targetPlaceCategory = targetAddress;
+    public VisitMission(String targetPlaceCategory) {
+        this.targetPlaceCategory = targetPlaceCategory;
     }
 
     @Override

--- a/src/main/java/com/example/live_backend/domain/mission/clover/service/CloverMissionService.java
+++ b/src/main/java/com/example/live_backend/domain/mission/clover/service/CloverMissionService.java
@@ -6,23 +6,25 @@ import com.example.live_backend.domain.mission.clover.Enum.MissionScoreCalculato
 import com.example.live_backend.domain.mission.clover.dto.*;
 import com.example.live_backend.domain.mission.clover.entity.CloverMission;
 import com.example.live_backend.domain.mission.clover.entity.CloverMissionRecord;
+import com.example.live_backend.domain.mission.clover.entity.VisitMission;
 import com.example.live_backend.domain.mission.clover.repository.CloverMissionRecordRepository;
 import com.example.live_backend.domain.mission.clover.repository.CloverMissionRepository;
 import com.example.live_backend.domain.mission.clover.repository.CloverMissionVectorRepository;
-import com.example.live_backend.domain.survey.vitality.dto.VitalityResultDto;
 import com.example.live_backend.domain.survey.vitality.enums.VitalityLevel;
 import com.example.live_backend.global.error.exception.CustomException;
 import com.example.live_backend.global.error.exception.ErrorCode;
+import com.example.live_backend.infra.kakao.feign.KakaoLocalFeign;
+import com.example.live_backend.infra.kakao.feign.dto.KakaoKeywordResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static java.util.Collections.emptyList;
 
@@ -36,14 +38,17 @@ public class CloverMissionService {
     private final MemberRepository memberRepository;
 
     private final CloverMissionRecordRepository cloverMissionRecordRepository;
+    private final KakaoLocalFeign kakaoLocalFeign;
 
     private final CloverMissionRecordService cloverMissionRecordService;
     private final LLMBasedQueryGeneratorService llmBasedQueryGeneratorService;
 
     private static final int DEFAULT_MISSION_COUNT = 10;
+    private static final int KAKAO_SEARCH_RADIUS = 2000;
+    private static final int KAKAO_SEARCH_SIZE = 1;
 
     @Transactional
-    public CloverMissionListResponseDto getCloverMissionList(Long memberId, double lat, double lon) {
+    public CloverMissionListResponseDto getCloverMissionList(Long memberId, BigDecimal lat, BigDecimal lon) {
 
         Member member = findUser(memberId);
         LocalDate today  = LocalDate.now();
@@ -51,7 +56,7 @@ public class CloverMissionService {
 
         // 만약 오늘의 클로버 미션 리스트를 조회했는데 결과가 없다면 미션 할당받는 아래의 로직 수행
         if (todayMissions.isEmpty()) {
-            List<CloverMissionRecord> newMissions = assignNewCloverMissions(member, emptyList());
+            List<CloverMissionRecord> newMissions = assignNewCloverMissions(member, emptyList(), lat, lon);
             return CloverMissionListResponseDto.of(memberId, newMissions);
         }
 
@@ -59,7 +64,7 @@ public class CloverMissionService {
     }
 
     @Transactional
-    public CloverMissionListResponseDto assignCloverMissionList(Long memberId) {
+    public CloverMissionListResponseDto assignCloverMissionList(Long memberId, BigDecimal lat, BigDecimal lon) {
 
         Member member = findUser(memberId);
         LocalDate today  = LocalDate.now();
@@ -70,7 +75,7 @@ public class CloverMissionService {
                 .map(CloverMissionRecord::getMissionId)
                 .toList();
 
-        List<CloverMissionRecord> newMissions = assignNewCloverMissions(member, excludedMissionIds);
+        List<CloverMissionRecord> newMissions = assignNewCloverMissions(member, excludedMissionIds, lat, lon);
 
         return CloverMissionListResponseDto.of(memberId, newMissions);
     }
@@ -125,7 +130,7 @@ public class CloverMissionService {
         return findByUserMissionId;
     }
 
-    private List<CloverMissionRecord> assignNewCloverMissions(Member member, List<Long> excludedIds) {
+    private List<CloverMissionRecord> assignNewCloverMissions(Member member, List<Long> excludedIds, BigDecimal lat, BigDecimal lon) {
 
         LLMProcessingResultDto strategy = generateSearchStrategy(member.getId());
 
@@ -138,7 +143,7 @@ public class CloverMissionService {
                 .limit(3)
                 .toList();
 
-        return createAndSaveMissionRecords(finalMissions, member);
+        return createAndSaveMissionRecords(finalMissions, member, lat, lon);
     }
 
     private Member findUser(Long memberId) {
@@ -180,12 +185,44 @@ public class CloverMissionService {
         return cloverMissionRepository.findAllById(missionIds);
     }
 
-    private List<CloverMissionRecord> createAndSaveMissionRecords(List<CloverMission> missions, Member member) {
-        List<CloverMissionRecord> missionRecords = missions.stream()
-                .map(mission -> CloverMissionRecord.from(mission, member))
-                .toList();
+    private List<CloverMissionRecord> createAndSaveMissionRecords(List<CloverMission> missions, Member member, BigDecimal lat, BigDecimal lon) {
 
-        return cloverMissionRecordRepository.saveAll(missionRecords);
+        List<CloverMissionRecord> visitMissionRecords = new ArrayList<>();
+        for (CloverMission mission : missions) {
+            CloverMissionRecord record = CloverMissionRecord.from(mission, member);
+
+            if (mission instanceof VisitMission visitMission) {
+                KakaoKeywordResponse response = kakaoLocalFeign.searchByKeyword(
+                        visitMission.getTargetPlaceCategory(),
+                        lon.doubleValue(),
+                        lat.doubleValue(),
+                        KAKAO_SEARCH_RADIUS,
+                        1,
+                        KAKAO_SEARCH_SIZE,
+                        "distance"
+                );
+
+                if (response.getDocuments().isEmpty()) {
+                    response = kakaoLocalFeign.searchByKeyword(
+                            visitMission.getTargetPlaceCategory(),
+                            lon.doubleValue(),
+                            lat.doubleValue(),
+                            10000,
+                            1,
+                            KAKAO_SEARCH_SIZE,
+                            "distance"
+                    );
+                }
+
+                if (!response.getDocuments().isEmpty()) {
+                    KakaoKeywordResponse.KakaoPlace place = response.getDocuments().get(0);
+                    record.setVisitPlace(place.getPlaceName(), place.getAddressName(), place.getY(), place.getX());
+                }
+            }
+            visitMissionRecords.add(record);
+        }
+
+        return cloverMissionRecordRepository.saveAll(visitMissionRecords);
     }
 
     private LLMProcessingResultDto generateDefaultSearchQuery() {

--- a/src/main/java/com/example/live_backend/domain/mission/clover/service/CloverMissionService.java
+++ b/src/main/java/com/example/live_backend/domain/mission/clover/service/CloverMissionService.java
@@ -43,7 +43,7 @@ public class CloverMissionService {
     private static final int DEFAULT_MISSION_COUNT = 10;
 
     @Transactional
-    public CloverMissionListResponseDto getCloverMissionList(Long memberId) {
+    public CloverMissionListResponseDto getCloverMissionList(Long memberId, double lat, double lon) {
 
         Member member = findUser(memberId);
         LocalDate today  = LocalDate.now();

--- a/src/main/java/com/example/live_backend/domain/mission/clover/service/CloverMissionService.java
+++ b/src/main/java/com/example/live_backend/domain/mission/clover/service/CloverMissionService.java
@@ -22,9 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
+import java.util.*;
 
 import static java.util.Collections.emptyList;
 
@@ -45,7 +43,9 @@ public class CloverMissionService {
 
     private static final int DEFAULT_MISSION_COUNT = 10;
     private static final int KAKAO_SEARCH_RADIUS = 2000;
-    private static final int KAKAO_SEARCH_SIZE = 1;
+    private static final int KAKAO_SEARCH_MAX_RADIUS = 20000;
+    private static final int KAKAO_SEARCH_SIZE = 5;
+    private static final int REQUIRED_MISSION_COUNT = 3;
 
     @Transactional
     public CloverMissionListResponseDto getCloverMissionList(Long memberId, BigDecimal lat, BigDecimal lon) {
@@ -139,16 +139,67 @@ public class CloverMissionService {
         // 벡터 DB에서 가져온 미션들에 필터링 적용
         List<CloverMission> weightedMissions = applyMissionWeighting(missions, strategy);
 
-        List<CloverMission> finalMissions = weightedMissions.stream()
-                .limit(3)
-                .toList();
-
-        return createAndSaveMissionRecords(finalMissions, member, lat, lon);
+        return selectAndSaveFinalMissions(weightedMissions, member, lat, lon);
     }
 
     private Member findUser(Long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private List<CloverMissionRecord> selectAndSaveFinalMissions(
+            List<CloverMission> weightedMissions, Member member, BigDecimal lat, BigDecimal lon) {
+
+        List<CloverMissionRecord> finalMissionRecords = new ArrayList<>();
+
+        for (CloverMission mission : weightedMissions) {
+            if (finalMissionRecords.size() >= REQUIRED_MISSION_COUNT) {
+                break;
+            }
+
+            buildCompletableMissionRecord(mission, member, lat, lon).ifPresent(finalMissionRecords::add);
+        }
+
+        if (finalMissionRecords.size() < REQUIRED_MISSION_COUNT) {
+            log.warn("미션 {} 개를 할당할 수 없습니다. 사용자({})에게 미션 {} 개만 할당되었습니다.",
+                    REQUIRED_MISSION_COUNT, member.getId(), finalMissionRecords.size());
+        }
+
+        return cloverMissionRecordRepository.saveAll(finalMissionRecords);
+    }
+
+    private Optional<CloverMissionRecord> buildCompletableMissionRecord(CloverMission mission, Member member, BigDecimal lat, BigDecimal lon) {
+        CloverMissionRecord record = CloverMissionRecord.from(mission, member);
+
+        if (mission instanceof VisitMission visitMission) {
+            return findPlaceForVisitMission(visitMission, lat, lon)
+                    .map(place -> {
+                        record.setVisitPlace(place.getPlaceName(), place.getAddressName(), place.getY(), place.getX());
+                        return record;
+                    });
+        }
+        return Optional.of(record);
+    }
+
+    private Optional<KakaoKeywordResponse.KakaoPlace> findPlaceForVisitMission(VisitMission mission, BigDecimal lat, BigDecimal lon) {
+        KakaoKeywordResponse response = kakaoLocalFeign.searchByKeyword(
+                mission.getTargetPlaceCategory(), lon.doubleValue(), lat.doubleValue(),
+                KAKAO_SEARCH_RADIUS, 1, KAKAO_SEARCH_SIZE, "distance"
+        );
+
+        if (response.getDocuments().isEmpty()) {
+            response = kakaoLocalFeign.searchByKeyword(
+                    mission.getTargetPlaceCategory(), lon.doubleValue(), lat.doubleValue(),
+                    KAKAO_SEARCH_MAX_RADIUS, 1, KAKAO_SEARCH_SIZE, "distance"
+            );
+        }
+
+        if (response.getDocuments().isEmpty()) {
+            return Optional.empty();
+        }
+
+        List<KakaoKeywordResponse.KakaoPlace> places = response.getDocuments();
+        return Optional.of(places.get(new Random().nextInt(places.size())));
     }
 
     private LLMProcessingResultDto generateSearchStrategy(Long memberId) {
@@ -183,46 +234,6 @@ public class CloverMissionService {
         );
 
         return cloverMissionRepository.findAllById(missionIds);
-    }
-
-    private List<CloverMissionRecord> createAndSaveMissionRecords(List<CloverMission> missions, Member member, BigDecimal lat, BigDecimal lon) {
-
-        List<CloverMissionRecord> visitMissionRecords = new ArrayList<>();
-        for (CloverMission mission : missions) {
-            CloverMissionRecord record = CloverMissionRecord.from(mission, member);
-
-            if (mission instanceof VisitMission visitMission) {
-                KakaoKeywordResponse response = kakaoLocalFeign.searchByKeyword(
-                        visitMission.getTargetPlaceCategory(),
-                        lon.doubleValue(),
-                        lat.doubleValue(),
-                        KAKAO_SEARCH_RADIUS,
-                        1,
-                        KAKAO_SEARCH_SIZE,
-                        "distance"
-                );
-
-                if (response.getDocuments().isEmpty()) {
-                    response = kakaoLocalFeign.searchByKeyword(
-                            visitMission.getTargetPlaceCategory(),
-                            lon.doubleValue(),
-                            lat.doubleValue(),
-                            10000,
-                            1,
-                            KAKAO_SEARCH_SIZE,
-                            "distance"
-                    );
-                }
-
-                if (!response.getDocuments().isEmpty()) {
-                    KakaoKeywordResponse.KakaoPlace place = response.getDocuments().get(0);
-                    record.setVisitPlace(place.getPlaceName(), place.getAddressName(), place.getY(), place.getX());
-                }
-            }
-            visitMissionRecords.add(record);
-        }
-
-        return cloverMissionRecordRepository.saveAll(visitMissionRecords);
     }
 
     private LLMProcessingResultDto generateDefaultSearchQuery() {

--- a/src/test/java/com/example/live_backend/domain/mission/clover/controller/CloverMissionControllerTest.java
+++ b/src/test/java/com/example/live_backend/domain/mission/clover/controller/CloverMissionControllerTest.java
@@ -16,6 +16,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.math.BigDecimal;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
@@ -35,6 +37,8 @@ class CloverMissionControllerTest {
 
     private final Long TEST_MEMBER_ID = 1L;
     private final Long TEST_USER_MISSION_ID = 100L;
+    private final BigDecimal TEST_LAT = new BigDecimal("37.123456");
+    private final BigDecimal TEST_LON = new BigDecimal("127.123456");
 
     @Nested
     @DisplayName("GET /api/v1/missions/clover")
@@ -47,16 +51,16 @@ class CloverMissionControllerTest {
             // Given
             CloverMissionListResponseDto mockResponse = new CloverMissionListResponseDto();
             given(principalDetails.getMemberId()).willReturn(TEST_MEMBER_ID);
-            given(cloverMissionService.getCloverMissionList(TEST_MEMBER_ID)).willReturn(mockResponse);
+            given(cloverMissionService.getCloverMissionList(TEST_MEMBER_ID, TEST_LAT, TEST_LON)).willReturn(mockResponse);
 
             // When
             ResponseHandler<CloverMissionListResponseDto> response =
-                    cloverMissionController.getCloverMissionList(principalDetails);
+                    cloverMissionController.getCloverMissionList(TEST_LAT, TEST_LON, principalDetails);
 
             // Then
             assertTrue(response.isSuccess());
             assertEquals(mockResponse, response.getData());
-            verify(cloverMissionService).getCloverMissionList(TEST_MEMBER_ID);
+            verify(cloverMissionService).getCloverMissionList(TEST_MEMBER_ID, TEST_LAT, TEST_LON);
         }
     }
 
@@ -276,16 +280,16 @@ class CloverMissionControllerTest {
             // Given
             CloverMissionListResponseDto mockResponse = new CloverMissionListResponseDto();
             given(principalDetails.getMemberId()).willReturn(TEST_MEMBER_ID);
-            given(cloverMissionService.assignCloverMissionList(TEST_MEMBER_ID)).willReturn(mockResponse);
+            given(cloverMissionService.assignCloverMissionList(TEST_MEMBER_ID, TEST_LAT, TEST_LON)).willReturn(mockResponse);
 
             // When
             ResponseHandler<CloverMissionListResponseDto> response = 
-                cloverMissionController.refillCloverMission(principalDetails);
+                cloverMissionController.refillCloverMission(TEST_LAT, TEST_LON, principalDetails);
 
             // Then
             assertTrue(response.isSuccess());
             assertEquals(mockResponse, response.getData());
-            verify(cloverMissionService).assignCloverMissionList(TEST_MEMBER_ID);
+            verify(cloverMissionService).assignCloverMissionList(TEST_MEMBER_ID, TEST_LAT, TEST_LON);
         }
     }
 }

--- a/src/test/java/com/example/live_backend/domain/mission/clover/service/CloverAdminServiceTest.java
+++ b/src/test/java/com/example/live_backend/domain/mission/clover/service/CloverAdminServiceTest.java
@@ -48,7 +48,7 @@ class CloverAdminServiceTest {
                 .requiredSeconds(600)
                 .requiredMeters(1000)
                 .illustrationUrl("https://image.url/photo.jpg")
-                .targetAddress("서울시 강남구 테헤란로")
+                .targetPlaceCategory("카페")
                 .relatedFeature("건강 취약층")
                 .activityDescription("도보 활동을 장려")
                 .expectedEffect("심폐지구력 향상")

--- a/src/test/java/com/example/live_backend/domain/mission/clover/service/CloverMissionServiceTest.java
+++ b/src/test/java/com/example/live_backend/domain/mission/clover/service/CloverMissionServiceTest.java
@@ -10,16 +10,15 @@ import com.example.live_backend.domain.mission.clover.Enum.CloverType;
 import com.example.live_backend.domain.mission.clover.Enum.MissionCategory;
 import com.example.live_backend.domain.mission.clover.Enum.MissionDifficulty;
 import com.example.live_backend.domain.mission.clover.dto.*;
-import com.example.live_backend.domain.mission.clover.entity.CloverMission;
-import com.example.live_backend.domain.mission.clover.entity.CloverMissionRecord;
-import com.example.live_backend.domain.mission.clover.entity.DistanceMission;
-import com.example.live_backend.domain.mission.clover.entity.TimerMission;
+import com.example.live_backend.domain.mission.clover.entity.*;
 import com.example.live_backend.domain.mission.clover.repository.CloverMissionRecordRepository;
 import com.example.live_backend.domain.mission.clover.repository.CloverMissionRepository;
 import com.example.live_backend.domain.mission.clover.repository.CloverMissionVectorRepository;
 import com.example.live_backend.domain.survey.vitality.enums.VitalityLevel;
 import com.example.live_backend.global.error.exception.CustomException;
 import com.example.live_backend.global.error.exception.ErrorCode;
+import com.example.live_backend.infra.kakao.feign.KakaoLocalFeign;
+import com.example.live_backend.infra.kakao.feign.dto.KakaoKeywordResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -31,6 +30,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
@@ -67,9 +67,15 @@ class CloverMissionServiceTest {
     @Mock
     private LLMBasedQueryGeneratorService llmBasedQueryGeneratorService;
 
+    @Mock
+    private KakaoLocalFeign kakaoLocalFeign;
+
+
     private Member mockMember;
     private final Long TEST_MEMBER_ID = 1L;
     private final Long TEST_USER_MISSION_ID = 10L;
+    private final BigDecimal TEST_LAT = new BigDecimal("37.123456");
+    private final BigDecimal TEST_LON = new BigDecimal("127.123456");
 
     @BeforeEach
     void setUp() {
@@ -106,7 +112,7 @@ class CloverMissionServiceTest {
                     .willReturn(existingMissions);
 
             // --- When ---
-            CloverMissionListResponseDto result = cloverMissionService.getCloverMissionList(TEST_MEMBER_ID);
+            CloverMissionListResponseDto result = cloverMissionService.getCloverMissionList(TEST_MEMBER_ID, TEST_LAT, TEST_LON);
 
             // --- Then ---
             assertThat(result).isNotNull();
@@ -159,7 +165,7 @@ class CloverMissionServiceTest {
             given(cloverMissionRecordRepository.saveAll(anyList())).willReturn(savedMissions);
 
             // --- When ---
-            CloverMissionListResponseDto result = cloverMissionService.getCloverMissionList(TEST_MEMBER_ID);
+            CloverMissionListResponseDto result = cloverMissionService.getCloverMissionList(TEST_MEMBER_ID, TEST_LAT, TEST_LON);
 
             // --- Then ---
             assertThat(result).isNotNull();
@@ -185,7 +191,7 @@ class CloverMissionServiceTest {
 
             // --- When & Then ---
             CustomException exception = assertThrows(CustomException.class, () ->
-                    cloverMissionService.getCloverMissionList(TEST_MEMBER_ID));
+                    cloverMissionService.getCloverMissionList(TEST_MEMBER_ID, TEST_LAT, TEST_LON));
 
             assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.MISSION_NOT_FOUND);
             verify(cloverMissionRepository, never()).findAllById(any());
@@ -201,7 +207,7 @@ class CloverMissionServiceTest {
 
             // --- When & Then ---
             CustomException exception = assertThrows(CustomException.class, () -> {
-                cloverMissionService.getCloverMissionList(TEST_MEMBER_ID);
+                cloverMissionService.getCloverMissionList(TEST_MEMBER_ID, TEST_LAT, TEST_LON);
             });
 
             assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.USER_NOT_FOUND);
@@ -269,12 +275,17 @@ class CloverMissionServiceTest {
         void getVisitMissionInfo() {
 
             // --- Given ---
+            String placeName = "스타벅스 강남점";
             String address = "서울시 강남구 테헤란로";
             CloverMissionRecord visitMission = CloverMissionRecord.builder()
                     .member(mockMember)
                     .cloverType(CloverType.VISIT)
-                    .targetAddress(address)
+                    .placeName(placeName)
+                    .address(address)
+                    .latitude(String.valueOf(TEST_LAT))
+                    .longitude(String.valueOf(TEST_LON))
                     .build();
+
             ReflectionTestUtils.setField(visitMission, "id", TEST_USER_MISSION_ID);
 
             given(cloverMissionRecordRepository.findByIdWithMember(eq(TEST_USER_MISSION_ID))).willReturn(Optional.of(visitMission));
@@ -285,7 +296,7 @@ class CloverMissionServiceTest {
             // --- Then ---
             verify(cloverMissionRecordRepository).findByIdWithMember(eq(TEST_USER_MISSION_ID));
             assertThat(actualDto).isNotNull();
-            assertThat(actualDto.getTargetAddress()).isEqualTo(address);
+            assertThat(actualDto.getAddress()).isEqualTo(address);
         }
 
         @Test
@@ -593,7 +604,7 @@ class CloverMissionServiceTest {
             given(cloverMissionRecordRepository.saveAll(anyList())).willReturn(savedNewRecords);
 
             // --- When ---
-            CloverMissionListResponseDto result = cloverMissionService.assignCloverMissionList(TEST_MEMBER_ID);
+            CloverMissionListResponseDto result = cloverMissionService.assignCloverMissionList(TEST_MEMBER_ID, TEST_LAT, TEST_LON);
 
             // --- Then ---
             assertThat(result).isNotNull();
@@ -656,7 +667,7 @@ class CloverMissionServiceTest {
             given(cloverMissionRecordRepository.saveAll(anyList())).willReturn(savedNewRecords);
 
             // --- When ---
-            CloverMissionListResponseDto result = cloverMissionService.assignCloverMissionList(TEST_MEMBER_ID);
+            CloverMissionListResponseDto result = cloverMissionService.assignCloverMissionList(TEST_MEMBER_ID, TEST_LAT, TEST_LON);
 
             // --- Then ---
             assertThat(result).isNotNull();
@@ -707,7 +718,7 @@ class CloverMissionServiceTest {
             given(cloverMissionRecordRepository.saveAll(anyList())).willReturn(savedNewRecords);
 
             // --- When ---
-            CloverMissionListResponseDto result = cloverMissionService.assignCloverMissionList(TEST_MEMBER_ID);
+            CloverMissionListResponseDto result = cloverMissionService.assignCloverMissionList(TEST_MEMBER_ID, TEST_LAT, TEST_LON);
 
             // --- Then ---
             assertThat(result).isNotNull();
@@ -769,7 +780,7 @@ class CloverMissionServiceTest {
             given(cloverMissionRecordRepository.saveAll(anyList())).willReturn(savedNewRecords);
 
             // --- When ---
-            CloverMissionListResponseDto result = cloverMissionService.assignCloverMissionList(TEST_MEMBER_ID);
+            CloverMissionListResponseDto result = cloverMissionService.assignCloverMissionList(TEST_MEMBER_ID, TEST_LAT, TEST_LON);
 
             // --- Then ---
             assertThat(result).isNotNull();
@@ -809,7 +820,7 @@ class CloverMissionServiceTest {
             given(cloverMissionRecordRepository.saveAll(anyList())).willReturn(savedNewRecords);
 
             // --- When ---
-            CloverMissionListResponseDto result = cloverMissionService.assignCloverMissionList(TEST_MEMBER_ID);
+            CloverMissionListResponseDto result = cloverMissionService.assignCloverMissionList(TEST_MEMBER_ID, TEST_LAT, TEST_LON);
 
             // --- Then ---
             assertThat(result).isNotNull();
@@ -832,7 +843,7 @@ class CloverMissionServiceTest {
             given(cloverMissionRecordRepository.saveAll(anyList())).willReturn(Collections.emptyList());
 
             // --- When ---
-            CloverMissionListResponseDto result = cloverMissionService.assignCloverMissionList(TEST_MEMBER_ID);
+            CloverMissionListResponseDto result = cloverMissionService.assignCloverMissionList(TEST_MEMBER_ID, TEST_LAT, TEST_LON);
 
             // --- Then ---
             assertThat(result).isNotNull();
@@ -850,7 +861,7 @@ class CloverMissionServiceTest {
 
             // --- When & Then ---
             CustomException exception = assertThrows(CustomException.class, () -> {
-                cloverMissionService.assignCloverMissionList(TEST_MEMBER_ID);
+                cloverMissionService.assignCloverMissionList(TEST_MEMBER_ID, TEST_LAT, TEST_LON);
             });
             assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.USER_NOT_FOUND);
         }
@@ -882,7 +893,7 @@ class CloverMissionServiceTest {
 
             // --- When & Then ---
             CustomException exception = assertThrows(CustomException.class, () ->
-                    cloverMissionService.assignCloverMissionList(TEST_MEMBER_ID));
+                    cloverMissionService.assignCloverMissionList(TEST_MEMBER_ID, TEST_LAT, TEST_LON));
 
             assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.MISSION_NOT_FOUND);
             verify(cloverMissionRepository, never()).findAllById(any());
@@ -944,7 +955,7 @@ class CloverMissionServiceTest {
             when(cloverMissionRecordRepository.saveAll(captor.capture())).thenAnswer(inv -> inv.getArgument(0));
 
             // --- When ---
-            cloverMissionService.assignCloverMissionList(TEST_MEMBER_ID);
+            cloverMissionService.assignCloverMissionList(TEST_MEMBER_ID, TEST_LAT, TEST_LON);
 
             // --- Then ---
             List<CloverMissionRecord> savedRecords = captor.getValue();
@@ -986,7 +997,7 @@ class CloverMissionServiceTest {
             when(cloverMissionRecordRepository.saveAll(captor.capture())).thenAnswer(inv -> inv.getArgument(0));
 
             // --- When ---
-            cloverMissionService.assignCloverMissionList(TEST_MEMBER_ID);
+            cloverMissionService.assignCloverMissionList(TEST_MEMBER_ID, TEST_LAT, TEST_LON);
 
             // --- Then ---
             List<CloverMissionRecord> savedRecords = captor.getValue();
@@ -1005,6 +1016,273 @@ class CloverMissionServiceTest {
             ReflectionTestUtils.setField(mission, "category", category);
             ReflectionTestUtils.setField(mission, "difficulty", difficulty);
             return mission;
+        }
+    }
+
+    @Nested
+    @DisplayName("방문 미션 장소 검색 및 할당")
+    class VisitMissionLocationAssignment {
+
+        @Test
+        @DisplayName("성공 - 방문 미션에 대해 카카오 API로 장소 검색 및 할당")
+        void assignCloverMissionList_Success_WithVisitMissionLocationFound() {
+
+            // --- Given ---
+            given(memberRepository.findById(TEST_MEMBER_ID)).willReturn(Optional.of(mockMember));
+            given(cloverMissionRecordRepository.findCloverMissionsList(eq(TEST_MEMBER_ID), any(LocalDate.class)))
+                    .willReturn(Collections.emptyList());
+
+            // LLM 관련 mocking
+            given(cloverMissionRecordService.getRecentMissionRecordsWithFeedback(TEST_MEMBER_ID))
+                    .willReturn(Collections.emptyList());
+
+            // 방문 미션과 일반 미션들 생성 (3개)
+            VisitMission visitMission = new VisitMission("카페");
+            ReflectionTestUtils.setField(visitMission, "id", 1L);
+            ReflectionTestUtils.setField(visitMission, "title", "카페 가기");
+            ReflectionTestUtils.setField(visitMission, "category", MissionCategory.HEALTH);
+            ReflectionTestUtils.setField(visitMission, "difficulty", MissionDifficulty.EASY);
+
+            TimerMission timerMission1 = new TimerMission(300);
+            ReflectionTestUtils.setField(timerMission1, "id", 2L);
+            ReflectionTestUtils.setField(timerMission1, "title", "5분 명상하기");
+            ReflectionTestUtils.setField(timerMission1, "category", MissionCategory.HEALTH);
+            ReflectionTestUtils.setField(timerMission1, "difficulty", MissionDifficulty.EASY);
+
+            DistanceMission distanceMission = new DistanceMission(1000);
+            ReflectionTestUtils.setField(distanceMission, "id", 3L);
+            ReflectionTestUtils.setField(distanceMission, "title", "1km 걷기");
+            ReflectionTestUtils.setField(distanceMission, "category", MissionCategory.HEALTH);
+            ReflectionTestUtils.setField(distanceMission, "difficulty", MissionDifficulty.NORMAL);
+
+            List<Long> missionIds = List.of(1L, 2L, 3L);
+            given(cloverMissionVectorRepository.searchSimilarMissionsIds(anyString(), eq(10), anyList()))
+                    .willReturn(missionIds);
+            given(cloverMissionRepository.findAllById(missionIds))
+                    .willReturn(List.of(visitMission, timerMission1, distanceMission));
+
+            // 카카오 API 응답 Mock (더 간단하게)
+            KakaoKeywordResponse.KakaoPlace place1 = mock(KakaoKeywordResponse.KakaoPlace.class);
+            given(place1.getPlaceName()).willReturn("스타벅스 강남점");
+            given(place1.getAddressName()).willReturn("서울 강남구 강남대로 390");
+            given(place1.getY()).willReturn("37.4979");
+            given(place1.getX()).willReturn("127.0276");
+
+            KakaoKeywordResponse kakaoResponse = mock(KakaoKeywordResponse.class);
+            given(kakaoResponse.getDocuments()).willReturn(List.of(place1));
+
+            given(kakaoLocalFeign.searchByKeyword(eq("카페"), eq(TEST_LON.doubleValue()), eq(TEST_LAT.doubleValue()), eq(2000), eq(1), eq(5), eq("distance")))
+                    .willReturn(kakaoResponse);
+
+            ArgumentCaptor<List<CloverMissionRecord>> captor = ArgumentCaptor.forClass(List.class);
+            when(cloverMissionRecordRepository.saveAll(captor.capture())).thenAnswer(inv -> inv.getArgument(0));
+
+            // --- When ---
+            CloverMissionListResponseDto result = cloverMissionService.assignCloverMissionList(TEST_MEMBER_ID, TEST_LAT, TEST_LON);
+
+            // --- Then ---
+            assertThat(result).isNotNull();
+            assertThat(result.getMissions().size()).isEqualTo(3);
+
+            List<CloverMissionRecord> savedRecords = captor.getValue();
+            assertThat(savedRecords.size()).isEqualTo(3);
+
+            // 방문 미션 확인
+            CloverMissionRecord visitRecord = savedRecords.stream()
+                    .filter(record -> record.getCloverType() == CloverType.VISIT)
+                    .findFirst()
+                    .orElseThrow();
+
+            assertThat(visitRecord.getPlaceName()).isEqualTo("스타벅스 강남점");
+            assertThat(visitRecord.getAddress()).isEqualTo("서울 강남구 강남대로 390");
+            assertThat(visitRecord.getLatitude()).isEqualTo("37.4979");
+            assertThat(visitRecord.getLongitude()).isEqualTo("127.0276");
+
+            verify(kakaoLocalFeign, times(1)).searchByKeyword(eq("카페"), anyDouble(), anyDouble(), eq(2000), eq(1), eq(5), eq("distance"));
+        }
+
+        @Test
+        @DisplayName("성공 - 첫 번째 검색 실패 후 재검색으로 장소 찾기")
+        void assignCloverMissionList_Success_RetrySearchWithLargerRadius() {
+
+            // --- Given ---
+            given(memberRepository.findById(TEST_MEMBER_ID)).willReturn(Optional.of(mockMember));
+            given(cloverMissionRecordRepository.findCloverMissionsList(eq(TEST_MEMBER_ID), any(LocalDate.class)))
+                    .willReturn(Collections.emptyList());
+
+            VisitMission visitMission = new VisitMission("도서관");
+            ReflectionTestUtils.setField(visitMission, "id", 1L);
+            ReflectionTestUtils.setField(visitMission, "title", "도서관 가기");
+            ReflectionTestUtils.setField(visitMission, "category", MissionCategory.HEALTH);
+            ReflectionTestUtils.setField(visitMission, "difficulty", MissionDifficulty.NORMAL);
+
+            List<Long> missionIds = List.of(1L);
+            given(cloverMissionVectorRepository.searchSimilarMissionsIds(anyString(), eq(10), anyList()))
+                    .willReturn(missionIds);
+            given(cloverMissionRepository.findAllById(missionIds))
+                    .willReturn(List.of(visitMission));
+
+            // 첫 번째 검색 (2km) - 실패
+            KakaoKeywordResponse emptyResponse = mock(KakaoKeywordResponse.class);
+            given(emptyResponse.getDocuments()).willReturn(Collections.emptyList());
+            given(kakaoLocalFeign.searchByKeyword(eq("도서관"), eq(TEST_LON.doubleValue()), eq(TEST_LAT.doubleValue()), eq(2000), eq(1), eq(5), eq("distance")))
+                    .willReturn(emptyResponse);
+
+            // 두 번째 검색 (20km) - 성공
+            KakaoKeywordResponse.KakaoPlace place = createMockPlace("강남구립도서관", "서울 강남구 대치동 123", "37.5010", "127.0300");
+            KakaoKeywordResponse successResponse = mock(KakaoKeywordResponse.class);
+            given(successResponse.getDocuments()).willReturn(List.of(place));
+            given(kakaoLocalFeign.searchByKeyword(eq("도서관"), eq(TEST_LON.doubleValue()), eq(TEST_LAT.doubleValue()), eq(20000), eq(1), eq(5), eq("distance")))
+                    .willReturn(successResponse);
+
+            ArgumentCaptor<List<CloverMissionRecord>> captor = ArgumentCaptor.forClass(List.class);
+            when(cloverMissionRecordRepository.saveAll(captor.capture())).thenAnswer(inv -> inv.getArgument(0));
+
+            // --- When ---
+            CloverMissionListResponseDto result = cloverMissionService.assignCloverMissionList(TEST_MEMBER_ID, TEST_LAT, TEST_LON);
+
+            // --- Then ---
+            assertThat(result).isNotNull();
+            assertThat(result.getMissions().size()).isEqualTo(1);
+
+            List<CloverMissionRecord> savedRecords = captor.getValue();
+            CloverMissionRecord visitRecord = savedRecords.get(0);
+
+            assertThat(visitRecord.getPlaceName()).isEqualTo("강남구립도서관");
+            assertThat(visitRecord.getAddress()).isEqualTo("서울 강남구 대치동 123");
+
+            verify(kakaoLocalFeign, times(1)).searchByKeyword(eq("도서관"), anyDouble(), anyDouble(), eq(2000), eq(1), eq(5), eq("distance"));
+            verify(kakaoLocalFeign, times(1)).searchByKeyword(eq("도서관"), anyDouble(), anyDouble(), eq(20000), eq(1), eq(5), eq("distance"));
+        }
+
+        @Test
+        @DisplayName("성공 - 방문 미션 장소 검색 완전 실패 시 해당 미션 제외")
+        void assignCloverMissionList_Success_ExcludeVisitMissionWhenNoPlaceFound() {
+
+            // --- Given ---
+            given(memberRepository.findById(TEST_MEMBER_ID)).willReturn(Optional.of(mockMember));
+            given(cloverMissionRecordRepository.findCloverMissionsList(eq(TEST_MEMBER_ID), any(LocalDate.class)))
+                    .willReturn(Collections.emptyList());
+
+            // 방문 미션과 일반 미션 혼합
+            VisitMission visitMission = new VisitMission("체육관");
+            ReflectionTestUtils.setField(visitMission, "id", 1L);
+            ReflectionTestUtils.setField(visitMission, "title", "체육관 가기");
+            ReflectionTestUtils.setField(visitMission, "category", MissionCategory.HEALTH);
+            ReflectionTestUtils.setField(visitMission, "difficulty", MissionDifficulty.NORMAL);
+
+            TimerMission timerMission = new TimerMission(300);
+            ReflectionTestUtils.setField(timerMission, "id", 2L);
+            ReflectionTestUtils.setField(timerMission, "title", "5분 명상하기");
+            ReflectionTestUtils.setField(timerMission, "category", MissionCategory.HEALTH);
+            ReflectionTestUtils.setField(timerMission, "difficulty", MissionDifficulty.EASY);
+
+            List<Long> missionIds = List.of(1L, 2L);
+            given(cloverMissionVectorRepository.searchSimilarMissionsIds(anyString(), eq(10), anyList()))
+                    .willReturn(missionIds);
+            given(cloverMissionRepository.findAllById(missionIds))
+                    .willReturn(List.of(visitMission, timerMission));
+
+            // 방문 미션 장소 검색 - 두 번 모두 실패
+            KakaoKeywordResponse emptyResponse = mock(KakaoKeywordResponse.class);
+            given(emptyResponse.getDocuments()).willReturn(Collections.emptyList());
+            given(kakaoLocalFeign.searchByKeyword(eq("체육관"), eq(TEST_LON.doubleValue()), eq(TEST_LAT.doubleValue()), eq(2000), eq(1), eq(5), eq("distance")))
+                    .willReturn(emptyResponse);
+            given(kakaoLocalFeign.searchByKeyword(eq("체육관"), eq(TEST_LON.doubleValue()), eq(TEST_LAT.doubleValue()), eq(20000), eq(1), eq(5), eq("distance")))
+                    .willReturn(emptyResponse);
+
+            ArgumentCaptor<List<CloverMissionRecord>> captor = ArgumentCaptor.forClass(List.class);
+            when(cloverMissionRecordRepository.saveAll(captor.capture())).thenAnswer(inv -> inv.getArgument(0));
+
+            // --- When ---
+            CloverMissionListResponseDto result = cloverMissionService.assignCloverMissionList(TEST_MEMBER_ID, TEST_LAT, TEST_LON);
+
+            // --- Then ---
+            assertThat(result).isNotNull();
+            assertThat(result.getMissions().size()).isEqualTo(1); // 방문 미션은 제외되고 타이머 미션만 남음
+
+            List<CloverMissionRecord> savedRecords = captor.getValue();
+            CloverMissionRecord remainingRecord = savedRecords.get(0);
+
+            assertThat(remainingRecord.getCloverType()).isEqualTo(CloverType.TIMER);
+            assertThat(remainingRecord.getMissionTitle()).isEqualTo("5분 명상하기");
+
+            verify(kakaoLocalFeign, times(1)).searchByKeyword(eq("체육관"), anyDouble(), anyDouble(), eq(2000), eq(1), eq(5), eq("distance"));
+            verify(kakaoLocalFeign, times(1)).searchByKeyword(eq("체육관"), anyDouble(), anyDouble(), eq(20000), eq(1), eq(5), eq("distance"));
+        }
+
+        @Test
+        @DisplayName("성공 - 방문 미션과 일반 미션이 함께 할당되는 경우")
+        void assignCloverMissionList_Success_MixedMissionTypes() {
+
+            // --- Given ---
+            given(memberRepository.findById(TEST_MEMBER_ID)).willReturn(Optional.of(mockMember));
+            given(cloverMissionRecordRepository.findCloverMissionsList(eq(TEST_MEMBER_ID), any(LocalDate.class)))
+                    .willReturn(Collections.emptyList());
+
+            VisitMission visitMission = new VisitMission("카페");
+            ReflectionTestUtils.setField(visitMission, "id", 1L);
+            ReflectionTestUtils.setField(visitMission, "title", "카페 가기");
+            ReflectionTestUtils.setField(visitMission, "category", MissionCategory.HEALTH);
+            ReflectionTestUtils.setField(visitMission, "difficulty", MissionDifficulty.EASY);
+
+            DistanceMission distanceMission = new DistanceMission(1000);
+            ReflectionTestUtils.setField(distanceMission, "id", 2L);
+            ReflectionTestUtils.setField(distanceMission, "title", "1km 걷기");
+            ReflectionTestUtils.setField(distanceMission, "category", MissionCategory.HEALTH);
+            ReflectionTestUtils.setField(distanceMission, "difficulty", MissionDifficulty.NORMAL);
+
+            List<Long> missionIds = List.of(1L, 2L);
+            given(cloverMissionVectorRepository.searchSimilarMissionsIds(anyString(), eq(10), anyList()))
+                    .willReturn(missionIds);
+            given(cloverMissionRepository.findAllById(missionIds))
+                    .willReturn(List.of(visitMission, distanceMission));
+
+            // 카카오 API 응답
+            KakaoKeywordResponse.KakaoPlace place = createMockPlace("스타벅스 테스트점", "서울 강남구 테스트로 123", "37.4979", "127.0276");
+            KakaoKeywordResponse kakaoResponse = mock(KakaoKeywordResponse.class);
+            given(kakaoResponse.getDocuments()).willReturn(List.of(place));
+            given(kakaoLocalFeign.searchByKeyword(eq("카페"), eq(TEST_LON.doubleValue()), eq(TEST_LAT.doubleValue()), eq(2000), eq(1), eq(5), eq("distance")))
+                    .willReturn(kakaoResponse);
+
+            ArgumentCaptor<List<CloverMissionRecord>> captor = ArgumentCaptor.forClass(List.class);
+            when(cloverMissionRecordRepository.saveAll(captor.capture())).thenAnswer(inv -> inv.getArgument(0));
+
+            // --- When ---
+            CloverMissionListResponseDto result = cloverMissionService.assignCloverMissionList(TEST_MEMBER_ID, TEST_LAT, TEST_LON);
+
+            // --- Then ---
+            assertThat(result).isNotNull();
+            assertThat(result.getMissions().size()).isEqualTo(2);
+
+            List<CloverMissionRecord> savedRecords = captor.getValue();
+
+            // 방문 미션 확인
+            CloverMissionRecord visitRecord = savedRecords.stream()
+                    .filter(record -> record.getCloverType() == CloverType.VISIT)
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(visitRecord.getPlaceName()).isEqualTo("스타벅스 테스트점");
+            assertThat(visitRecord.getAddress()).isEqualTo("서울 강남구 테스트로 123");
+
+            // 거리 미션 확인
+            CloverMissionRecord distanceRecord = savedRecords.stream()
+                    .filter(record -> record.getCloverType() == CloverType.DISTANCE)
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(distanceRecord.getPlaceName()).isNull();
+            assertThat(distanceRecord.getRequiredMeters()).isEqualTo(1000);
+
+            verify(kakaoLocalFeign, times(1)).searchByKeyword(eq("카페"), anyDouble(), anyDouble(), eq(2000), eq(1), eq(5), eq("distance"));
+        }
+
+        private KakaoKeywordResponse.KakaoPlace createMockPlace(String placeName, String address, String lat, String lon) {
+            KakaoKeywordResponse.KakaoPlace place = mock(KakaoKeywordResponse.KakaoPlace.class);
+            given(place.getPlaceName()).willReturn(placeName);
+            given(place.getAddressName()).willReturn(address);
+            given(place.getY()).willReturn(lat);
+            given(place.getX()).willReturn(lon);
+            return place;
         }
     }
 }


### PR DESCRIPTION
### ✅ PR 타입 (하나 이상 선택해주세요)

- [x]  기능 추가
- [ ]  기능 삭제
- [x]  리팩토링 / 코드 개선
- [ ]  의존성 / 환경 설정 변경
- [ ]  버그 수정
- [ ]  기타 (하단에 설명)

&nbsp;
### ✨ 어떤 내용인가요?

> 사용자의 현재 위치를 기반으로 방문 미션에 대한 구체적인 장소를 추천하는 기능을 추가했습니다. 카카오 로컬 API를 통해 "카페 가기" 미션을 "카페 가기 (스타벅스 강남점)"처럼 구체적인 장소로 추천합니다.

&nbsp;
### 🔍 작업 상세 내용

- [x] API 파라미터 추가
  - GET /api/v1/missions/clover와 GET /api/v1/missions/clover/refill API에 위도(lat), 경도(lon) 쿼리 파라미터 추가
  - 컨트롤러, 서비스, 문서화 인터페이스 모두 수정
- [x] 카카오 로컬 API 연동
  - 기존 `KakaoLocalFeign` 인터페이스를 활용하여 키워드 기반 장소 검색 구현
  - 초기 검색(2km) 실패 시 재검색(10km) 로직 추가
  - 검색된 장소 중 무작위 선택으로 추천의 다양성 확보
- [x] 데이터베이스 스키마 확장
  - `CloverMissionRecord` 엔티티에 `placeName`, `address`, `latitude`, `longitude `필드 추가
  - 방문 미션에 대한 구체적인 장소 정보 저장 기능 구현
- [x] 미션 할당 로직 개선
  - 방문 미션 장소 검색 실패 시 해당 미션을 제외하고 다음 우선순위 미션으로 대체
  - 사용자에게 항상 수행 가능한 3개의 미션 보장
- [x] 클라이언트 응답 개선
  - 미션 상세 조회 API 응답에 추천 장소 정보 포함
  - 미션 제목을 "미션명 (장소명)" 형태로 조합하여 반환
- [x] 코드 가독성 향상
  - 메소드 분리 및 명확한 네이밍으로 가독성 향상
  - `selectAndSaveFinalMissions`, `buildCompletableMissionRecord`, `findPlaceForVisitMission` 등 역할별 메소드 분리
- [x] 단위 테스트 코드 작성
  - 방문 미션 장소 검색 성공/실패 시나리오 테스트
  - 재검색 로직, 미션 제외 처리, 혼합 미션 타입 처리 테스트
  - 기존 테스트 코드의 새로운 파라미터 대응

&nbsp;
### 💬 리뷰어에게 전달할 내용 

> 방문 미션과 일반 미션이 혼재할 때의 처리 로직 위주롤 봐주세요!

&nbsp;
### 🔗 관련 이슈
#86