### PR TITLE
[Refactor/#103] 분석 API 수정

### DIFF
--- a/src/main/java/com/example/live_backend/domain/analysis/controller/AnalysisController.java
+++ b/src/main/java/com/example/live_backend/domain/analysis/controller/AnalysisController.java
@@ -65,11 +65,12 @@ public class AnalysisController implements AnalysisControllerDocs {
     @AuthenticatedApi(reason = "전월 대비 클로버 미션 TOP3 성장 카테고리 조회는 로그인한 사용자만 가능합니다")
     @GetMapping("/clover/monthly-growth")
     public ResponseHandler<MonthlyGrowthResponseDto> getMonthlyGrowth(
-            @AuthenticationPrincipal PrincipalDetails userDetails
+            @AuthenticationPrincipal PrincipalDetails userDetails,
+            @RequestParam(name = "yearMonth") String yearMonth
     ) {
 
         Long memberId = userDetails.getMemberId();
-        YearMonth ym = YearMonth.now();
+        YearMonth ym = YearMonth.parse(yearMonth, DateTimeFormatter.ofPattern("yyyy-MM"));
 
         return ResponseHandler.success(analysisService.getMonthlyGrowthTop3(memberId, ym));
     }

--- a/src/main/java/com/example/live_backend/domain/analysis/controller/docs/AnalysisControllerDocs.java
+++ b/src/main/java/com/example/live_backend/domain/analysis/controller/docs/AnalysisControllerDocs.java
@@ -42,7 +42,9 @@ public interface AnalysisControllerDocs {
     @Operation(summary = "전월 대비 클로버 미션 TOP3 성장 카테고리 조회", description = "현재 월 기준 전월 대비 성장한 TOP3 클로버 미션의 카테고리를 조회합니다.")
     ResponseHandler<MonthlyGrowthResponseDto> getMonthlyGrowth(
             @Parameter(hidden = true)
-            @AuthenticationPrincipal PrincipalDetails userDetails
+            @AuthenticationPrincipal PrincipalDetails userDetails,
+            @Parameter(description = "조회 기준 년,월", example = "2025-08")
+            @RequestParam(name = "yearMonth") String yearMonth
     );
 
     @Operation(summary = "마이미션 월별 완료율 조회", description = "마이미션의 월별 완료율을 조회합니다.")

--- a/src/main/java/com/example/live_backend/domain/analysis/dto/DailyCompletedMissionsResponseDto.java
+++ b/src/main/java/com/example/live_backend/domain/analysis/dto/DailyCompletedMissionsResponseDto.java
@@ -20,7 +20,8 @@ public class DailyCompletedMissionsResponseDto {
     @Getter
     @Builder
     public static class CompletedMission {
-        private Long userMissionId;
+        private Long missionId;
+        private Long missionRecordId;
         private String missionTitle;
         private LocalDateTime completedAt;
     }
@@ -28,7 +29,8 @@ public class DailyCompletedMissionsResponseDto {
     public static DailyCompletedMissionsResponseDto from(LocalDate date, List<CloverMissionRecord> completed) {
         List<CompletedMission> CompletedMissions = completed.stream()
                 .map(r -> CompletedMission.builder()
-                        .userMissionId(r.getMissionId())
+                        .missionId(r.getMissionId())
+                        .missionRecordId(r.getId())
                         .missionTitle(r.getMissionTitle())
                         .completedAt(r.getCompletedAt())
                         .build())

--- a/src/main/java/com/example/live_backend/domain/analysis/dto/DailyCompletedMyMissionsResponseDto.java
+++ b/src/main/java/com/example/live_backend/domain/analysis/dto/DailyCompletedMyMissionsResponseDto.java
@@ -15,13 +15,13 @@ public class DailyCompletedMyMissionsResponseDto {
 
     private LocalDate date;
     private DayOfWeek dayOfWeek;
-    private List<CompletedMyMission> completedMyMissions;
+    private List<CompletedMyMission> completedMissions;
 
     @Getter
     @Builder
     public static class CompletedMyMission {
-        private Long myMissionRecordId;
-        private Long myMissionId;
+        private Long missionId;
+        private Long missionRecordId;
         private String missionTitle;
         private LocalDateTime completedAt;
     }
@@ -29,8 +29,8 @@ public class DailyCompletedMyMissionsResponseDto {
     public static DailyCompletedMyMissionsResponseDto from(LocalDate date, List<MyMissionRecord> completed) {
         List<CompletedMyMission> completedMyMissions = completed.stream()
                 .map(r -> CompletedMyMission.builder()
-                        .myMissionRecordId(r.getId())
-                        .myMissionId(r.getMyMission().getId())
+                        .missionRecordId(r.getId())
+                        .missionId(r.getMyMission().getId())
                         .missionTitle(r.getMyMission().getTitle())
                         .completedAt(r.getCompletedAt())
                         .build())
@@ -39,7 +39,7 @@ public class DailyCompletedMyMissionsResponseDto {
         return DailyCompletedMyMissionsResponseDto.builder()
                 .date(date)
                 .dayOfWeek(date.getDayOfWeek())
-                .completedMyMissions(completedMyMissions)
+                .completedMissions(completedMyMissions)
                 .build();
     }
 }

--- a/src/test/java/com/example/live_backend/domain/analysis/controller/AnalysisControllerTest.java
+++ b/src/test/java/com/example/live_backend/domain/analysis/controller/AnalysisControllerTest.java
@@ -146,7 +146,7 @@ class AnalysisControllerTest {
             given(analysisService.getMonthlyGrowthTop3(eq(MEMBER_ID), any(YearMonth.class))).willReturn(dto);
 
             // When
-            ResponseHandler<MonthlyGrowthResponseDto> response = analysisController.getMonthlyGrowth(member);
+            ResponseHandler<MonthlyGrowthResponseDto> response = analysisController.getMonthlyGrowth(member, String.valueOf(expectedYm));
 
             // Then
             assertThat(response.isSuccess()).isTrue();

--- a/src/test/java/com/example/live_backend/domain/analysis/controller/AnalysisControllerTest.java
+++ b/src/test/java/com/example/live_backend/domain/analysis/controller/AnalysisControllerTest.java
@@ -113,6 +113,8 @@ class AnalysisControllerTest {
             // Then
             assertThat(response.isSuccess()).isTrue();
             assertThat(response.getData()).isEqualTo(dto);
+            assertThat(response.getData().getDate()).isEqualTo(date);
+            assertThat(response.getData().getDayOfWeek()).isEqualTo(DayOfWeek.SATURDAY);
             verify(analysisService).getDailyCompleted(eq(MEMBER_ID), eq(date));
         }
     }

--- a/src/test/java/com/example/live_backend/domain/analysis/service/AnalysisServiceTest.java
+++ b/src/test/java/com/example/live_backend/domain/analysis/service/AnalysisServiceTest.java
@@ -243,9 +243,9 @@ class AnalysisServiceTest {
             assertThat(result.getDate()).isEqualTo(date);
             assertThat(result.getDayOfWeek()).isEqualTo(date.getDayOfWeek());
             assertThat(result.getCompletedMissions().size()).isEqualTo(2);
-            assertThat(result.getCompletedMissions().get(0).getUserMissionId()).isEqualTo(101L);
+            assertThat(result.getCompletedMissions().get(0).getMissionId()).isEqualTo(101L);
             assertThat(result.getCompletedMissions().get(0).getMissionTitle()).isEqualTo("Daily-1");
-            assertThat(result.getCompletedMissions().get(1).getUserMissionId()).isEqualTo(102L);
+            assertThat(result.getCompletedMissions().get(1).getMissionId()).isEqualTo(102L);
             assertThat(result.getCompletedMissions().get(1).getMissionTitle()).isEqualTo("Daily-2");
 
             verify(cloverMissionRecordRepository).findCompletedOnDate(
@@ -544,9 +544,9 @@ class AnalysisServiceTest {
             // Then
             assertThat(result.getDate()).isEqualTo(date);
             assertThat(result.getDayOfWeek()).isEqualTo(date.getDayOfWeek());
-            assertThat(result.getCompletedMyMissions().size()).isEqualTo(2);
-            assertThat(result.getCompletedMyMissions().get(0).getMissionTitle()).isEqualTo("아침 조깅");
-            assertThat(result.getCompletedMyMissions().get(1).getMissionTitle()).isEqualTo("저녁 산책");
+            assertThat(result.getCompletedMissions().size()).isEqualTo(2);
+            assertThat(result.getCompletedMissions().get(0).getMissionTitle()).isEqualTo("아침 조깅");
+            assertThat(result.getCompletedMissions().get(1).getMissionTitle()).isEqualTo("저녁 산책");
 
             verify(myMissionRecordRepository).findCompletedOnDate(
                     eq(memberId),


### PR DESCRIPTION
### ✅ PR 타입 (하나 이상 선택해주세요)

- [ ]  기능 추가
- [ ]  기능 삭제
- [x]  리팩토링 / 코드 개선
- [ ]  의존성 / 환경 설정 변경
- [ ]  버그 수정
- [ ]  기타 (하단에 설명)

&nbsp;
### ✨ 어떤 내용인가요?

> 월별 성장 카테고리 조회 API에서 클라이언트가 원하는 월을 지정할 수 있도록 `yearMonth` 파라미터를 추가하고, 일별 완료 목록 조회에서 마이미션과 클로버 미션의 응답 구조를 통일하도록 수정했습니다.
> 

&nbsp;
### 🔍 작업 상세 내용

- [x] `getMonthlyGrowth` API 파라미터 추가
  - 기존 `YearMonth.now()` 사용에서 클라이언트로부터 `yearMonth` 파라미터를 받도록 변경
  - getParticipation API와 동일한 방식으로 구현
- [x] 일별 완료 목록 조회 응답 구조 통일
  - 마이미션과 클로버 미션의 응답 DTO 구조를 일관되게 수정

&nbsp;

### 🔗 관련 이슈 
#103 