### PR TITLE
[Fix/#114] 테스트 환경에서 mock vectorstore 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -156,5 +156,7 @@ jacocoTestCoverageVerification {
 }
 
 test {
+    useJUnitPlatform()
+    systemProperty 'spring.profiles.active', 'test'
 	finalizedBy jacocoTestReport
 }

--- a/src/test/java/com/example/live_backend/config/TestVectorStoreConfig.java
+++ b/src/test/java/com/example/live_backend/config/TestVectorStoreConfig.java
@@ -1,0 +1,48 @@
+package com.example.live_backend.config;
+
+import org.springframework.ai.document.Document;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.ai.vectorstore.filter.Filter;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+
+import java.util.Collections;
+import java.util.List;
+
+@TestConfiguration
+@Profile("test")
+public class TestVectorStoreConfig {
+
+    @Bean
+    @Primary
+    public VectorStore mockVectorStore() {
+        return new VectorStore() {
+            @Override
+            public void add(List<Document> documents) {
+            }
+
+            @Override
+            public void delete(List<String> idList) {
+
+            }
+
+            @Override
+            public void delete(Filter.Expression filterExpression) {
+
+            }
+
+            @Override
+            public List<Document> similaritySearch(SearchRequest request) {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public List<Document> similaritySearch(String query) {
+                return Collections.emptyList();
+            }
+        };
+    }
+}

--- a/src/test/java/com/example/live_backend/config/TestVectorStoreConfig.java
+++ b/src/test/java/com/example/live_backend/config/TestVectorStoreConfig.java
@@ -4,15 +4,15 @@ import org.springframework.ai.document.Document;
 import org.springframework.ai.vectorstore.SearchRequest;
 import org.springframework.ai.vectorstore.VectorStore;
 import org.springframework.ai.vectorstore.filter.Filter;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 
 import java.util.Collections;
 import java.util.List;
 
-@TestConfiguration
+@Configuration
 @Profile("test")
 public class TestVectorStoreConfig {
 


### PR DESCRIPTION
### ✅ PR 타입 (하나 이상 선택해주세요)

- [ ]  기능 추가
- [ ]  기능 삭제
- [x]  리팩토링 / 코드 개선
- [x]  의존성 / 환경 설정 변경
- [ ]  버그 수정
- [ ]  기타 (하단에 설명)

&nbsp;
### ✨ 어떤 내용인가요?
> GitHub Actions에서 테스트 실행 시 Qdrant 연결 실패로 빌드 실패하는 문제 해결

&nbsp;
### 🔍 작업 상세 내용

- 테스트 환경에서 Mock VectorStore를 사용하도록 설정
  - TestVectorStoreConfig 추가
     - `src/test/java/com/example/live_backend/config/TestVectorStoreConfig.java` 생성
     - `@Profile("test")` 적용으로 테스트 환경에서만 활성화
     - Mock VectorStore Bean 생성
  - build.gradle 수정
    - `test` 태스크에 `spring.profiles.active=test` 설정 추가
    - 테스트 실행 시 test 프로파일 자동 활성화

&nbsp;
### 🔗 관련 이슈
#114