### PR TITLE
[Refactor/#117] 클로버 미션 로직 수정

### DIFF
--- a/src/main/java/com/example/live_backend/domain/mission/clover/dto/CloverMissionRecordRequestDto.java
+++ b/src/main/java/com/example/live_backend/domain/mission/clover/dto/CloverMissionRecordRequestDto.java
@@ -19,6 +19,6 @@ public class CloverMissionRecordRequestDto {
     @Schema(description = "체감 난이도", example = "EASY")
     private MissionDifficulty feedbackDifficulty;
 
-    @Schema(description = "인증샷 이미지 URL (PHOTO 미션일 때 필수, AWS S3 access Url)", example = "https://s3.amazonaws.com/bucket/mission-certification/image.jpg")
+    @Schema(description = "인증샷 이미지 URL (AWS S3 access Url)", example = "https://s3.amazonaws.com/bucket/mission-certification/image.jpg")
     private String imageUrl;
 }

--- a/src/main/java/com/example/live_backend/domain/mission/clover/entity/CloverMissionRecord.java
+++ b/src/main/java/com/example/live_backend/domain/mission/clover/entity/CloverMissionRecord.java
@@ -143,9 +143,10 @@ public class CloverMissionRecord {
     }
 
     public void startMission() {
-        /*if (this.cloverMissionStatus != CloverMissionStatus.ASSIGNED && this.cloverMissionStatus != CloverMissionStatus.PAUSED) {
+        if (this.cloverMissionStatus == CloverMissionStatus.COMPLETED) {
             throw new CustomException(ErrorCode.INVALID_MISSION_STATUS);
-        }*/
+        }
+
         this.cloverMissionStatus = CloverMissionStatus.STARTED;
     }
 

--- a/src/main/java/com/example/live_backend/domain/mission/clover/service/CloverMissionRecordService.java
+++ b/src/main/java/com/example/live_backend/domain/mission/clover/service/CloverMissionRecordService.java
@@ -36,8 +36,11 @@ public class CloverMissionRecordService {
             if (requestDto.getImageUrl() == null || requestDto.getImageUrl().trim().isEmpty()) {
                 throw new CustomException(ErrorCode.IMAGE_URL_REQUIRED);
             }
+        }
+
+        if (requestDto.getImageUrl() != null && !requestDto.getImageUrl().trim().isEmpty()) {
             missionRecord.addFeedbackWithImage(
-                    requestDto.getFeedbackComment(), 
+                    requestDto.getFeedbackComment(),
                     requestDto.getFeedbackDifficulty(),
                     requestDto.getImageUrl()
             );
@@ -67,15 +70,33 @@ public class CloverMissionRecordService {
         CloverMissionRecord missionRecord = missionRecordRepository.findByIdWithMember(requestDto.getUserMissionId())
                 .orElseThrow(() -> new CustomException(ErrorCode.MISSION_NOT_FOUND));
 
+        if (!(missionRecord.getId().equals(requestDto.getUserMissionId()))) {
+            throw new CustomException(ErrorCode.MISSION_FORBIDDEN);
+        }
+
         if (!missionRecord.getMember().getId().equals(memberId)) {
             throw new CustomException(ErrorCode.MISSION_FORBIDDEN);
         }
 
-        if (missionRecord.getCloverType() == CloverType.PHOTO && requestDto.getImageUrl() != null) {
-            if (requestDto.getImageUrl().trim().isEmpty()) {
+        if (missionRecord.getCloverType() == CloverType.PHOTO) {
+            if (requestDto.getImageUrl() == null || requestDto.getImageUrl().trim().isEmpty()) {
                 throw new CustomException(ErrorCode.IMAGE_URL_REQUIRED);
             }
+        }
 
+        if (requestDto.getImageUrl() != null && !requestDto.getImageUrl().trim().isEmpty()) {
+            missionRecord.addFeedbackWithImage(
+                    requestDto.getFeedbackComment(),
+                    requestDto.getFeedbackDifficulty(),
+                    requestDto.getImageUrl()
+            );
+        } else {
+            missionRecord.addFeedback(
+                    requestDto.getFeedbackComment(),
+                    requestDto.getFeedbackDifficulty());
+        }
+
+        if (requestDto.getImageUrl() != null && !requestDto.getImageUrl().trim().isEmpty()) {
             missionRecord.updateFeedbackWithImage(
                     requestDto.getFeedbackComment(),
                     requestDto.getFeedbackDifficulty(),

--- a/src/test/java/com/example/live_backend/domain/mission/clover/service/CloverMissionRecordServiceTest.java
+++ b/src/test/java/com/example/live_backend/domain/mission/clover/service/CloverMissionRecordServiceTest.java
@@ -130,6 +130,70 @@ class CloverMissionRecordServiceTest {
 			assertThat(response.getImageUrl()).isEqualTo("https://s3/url.jpg");
 		}
 
+        @Test
+        @DisplayName("성공 - 비포토 타입 미션에 이미지 포함 피드백 추가")
+        void addMissionRecord_success_nonPhotoWithImage() {
+            // Given
+            CloverMissionRecord record = createCompletedRecord(CloverType.TIMER);
+            given(missionRecordRepository.findByIdWithMember(TEST_USER_MISSION_ID)).willReturn(Optional.of(record));
+            CloverMissionRecordRequestDto request = buildRequest(
+                    TEST_USER_MISSION_ID,
+                    "이미지와 함께",
+                    MissionDifficulty.NORMAL,
+                    "https://s3/non-photo-image.jpg"
+            );
+
+            // When
+            CloverMissionRecordResponseDto response = cloverMissionRecordService.addMissionRecord(TEST_MEMBER_ID, request);
+
+            // Then
+            assertThat(response.getUserMissionId()).isEqualTo(TEST_USER_MISSION_ID);
+            assertThat(response.getFeedbackComment()).isEqualTo("이미지와 함께");
+            assertThat(response.getImageUrl()).isEqualTo("https://s3/non-photo-image.jpg");
+        }
+
+        @Test
+        @DisplayName("성공 - DISTANCE 타입 미션에 이미지 포함 피드백 추가")
+        void addMissionRecord_success_distanceWithImage() {
+            // Given
+            CloverMissionRecord record = createCompletedRecord(CloverType.DISTANCE);
+            given(missionRecordRepository.findByIdWithMember(TEST_USER_MISSION_ID)).willReturn(Optional.of(record));
+            CloverMissionRecordRequestDto request = buildRequest(
+                    TEST_USER_MISSION_ID,
+                    "거리 미션 인증샷",
+                    MissionDifficulty.HARD,
+                    "https://s3/distance-proof.jpg"
+            );
+
+            // When
+            CloverMissionRecordResponseDto response = cloverMissionRecordService.addMissionRecord(TEST_MEMBER_ID, request);
+
+            // Then
+            assertThat(response.getImageUrl()).isEqualTo("https://s3/distance-proof.jpg");
+            assertThat(response.getCloverType()).isEqualTo("DISTANCE");
+        }
+
+        @Test
+        @DisplayName("성공 - VISIT 타입 미션에 이미지 포함 피드백 추가")
+        void addMissionRecord_success_visitWithImage() {
+            // Given
+            CloverMissionRecord record = createCompletedRecord(CloverType.VISIT);
+            given(missionRecordRepository.findByIdWithMember(TEST_USER_MISSION_ID)).willReturn(Optional.of(record));
+            CloverMissionRecordRequestDto request = buildRequest(
+                    TEST_USER_MISSION_ID,
+                    "방문 인증",
+                    MissionDifficulty.EASY,
+                    "https://s3/visit-proof.jpg"
+            );
+
+            // When
+            CloverMissionRecordResponseDto response = cloverMissionRecordService.addMissionRecord(TEST_MEMBER_ID, request);
+
+            // Then
+            assertThat(response.getImageUrl()).isEqualTo("https://s3/visit-proof.jpg");
+            assertThat(response.getCloverType()).isEqualTo("VISIT");
+        }
+
 		@Test
 		@DisplayName("실패 - 존재하지 않는 미션 기록")
 		void addMissionRecord_notFound() {
@@ -277,6 +341,47 @@ class CloverMissionRecordServiceTest {
 			// Then
 			assertThat(dto.getImageUrl()).isEqualTo("https://s3/new_image_url.jpg");
 		}
+
+        @Test
+        @DisplayName("성공 - 비포토 타입 미션에 이미지 포함 수정")
+        void updateMissionRecord_success_nonPhotoWithImage() {
+            // Given
+            CloverMissionRecord record = createCompletedRecord(CloverType.TIMER);
+            given(missionRecordRepository.findByIdWithMember(TEST_USER_MISSION_ID)).willReturn(Optional.of(record));
+            CloverMissionRecordRequestDto request = buildRequest(
+                    TEST_USER_MISSION_ID,
+                    "타이머 미션 이미지 추가",
+                    MissionDifficulty.NORMAL,
+                    "https://s3/timer-image.jpg"
+            );
+
+            // When
+            CloverMissionRecordResponseDto response = cloverMissionRecordService.updateMissionRecord(TEST_MEMBER_ID, request);
+
+            // Then
+            assertThat(response.getImageUrl()).isEqualTo("https://s3/timer-image.jpg");
+            assertThat(response.getFeedbackComment()).isEqualTo("타이머 미션 이미지 추가");
+        }
+
+        @Test
+        @DisplayName("성공 - DISTANCE 타입 미션에 이미지 포함 수정")
+        void updateMissionRecord_success_distanceWithImage() {
+            // Given
+            CloverMissionRecord record = createCompletedRecord(CloverType.DISTANCE);
+            given(missionRecordRepository.findByIdWithMember(TEST_USER_MISSION_ID)).willReturn(Optional.of(record));
+            CloverMissionRecordRequestDto request = buildRequest(
+                    TEST_USER_MISSION_ID,
+                    "거리 미션 이미지 수정",
+                    MissionDifficulty.HARD,
+                    "https://s3/distance-updated.jpg"
+            );
+
+            // When
+            CloverMissionRecordResponseDto response = cloverMissionRecordService.updateMissionRecord(TEST_MEMBER_ID, request);
+
+            // Then
+            assertThat(response.getImageUrl()).isEqualTo("https://s3/distance-updated.jpg");
+        }
 
 		@Test
 		@DisplayName("실패 - 포토 타입 빈 이미지 문자열")


### PR DESCRIPTION
### ✅ PR 타입 (하나 이상 선택해주세요)

- [ ]  기능 추가
- [ ]  기능 삭제
- [x]  리팩토링 / 코드 개선
- [ ]  의존성 / 환경 설정 변경
- [ ]  버그 수정
- [ ]  기타 (하단에 설명)

&nbsp;
### ✨ 어떤 내용인가요?

> 포토 미션이 아닌 다른 타입의 미션에서도 선택적으로 이미지를 저장할 수 있도록 개선했습니다.
> 미션의 상태를 STARTED에서도 STARTED로 변경하는 api를 호출할 수 있도록 수정했습니다.

&nbsp;
### 🔍 작업 상세 내용
- [x] 클로버 미션의 상태를 STARTED로 변경하는 api의 로직 수정
    - 기존에는 STARTED 상태에서 해당 api를 호출하면 에러 발생했음 -> 수정해서  STARTED에서도 api 호출할 수 있도록 함
- [x] 클로버 미션 기록 추가/수정 로직 개선
    - 포토 미션: 이미지 필수 (기존 동작 유지)
    - 기타 미션(TIMER, DISTANCE, VISIT): 이미지 선택적 저장 가능
    - 이미지 URL 존재 여부로 분기 처리하도록 변경
- [x] 테스트 코드 추가
    - 비포토 타입 미션에 이미지 포함 피드백 추가/수정 케이스 추가
    - TIMER, DISTANCE, VISIT 타입별 이미지 포함 테스트 작성

&nbsp;

&nbsp;
### 🔗 관련 이슈
#117 