### PR TITLE
[Feat/#119] SurveyDataInitializer를 통한 설문 문항 초기화 기능 추가

### DIFF
--- a/src/main/java/com/example/live_backend/domain/survey/service/SurveyService.java
+++ b/src/main/java/com/example/live_backend/domain/survey/service/SurveyService.java
@@ -89,9 +89,9 @@ public class SurveyService {
         log.info("설문 응답 제출 완료 - 응답 ID: {}, 사용자 ID: {}", saved.getId(), memberId);
 
         VitalityResultDto vitalityResult = vitalityService.analyzeVitality(saved.getId());
-        member.updateVitalityLevel(vitalityResult.getLevel());
+        member.updateVitalityLevel(vitalityResult.getVitalityLevel());
 
-        log.info("활력 분석 완료 - 응답 ID: {}, 활력 수준: {}", saved.getId(), vitalityResult.getLevel());
+        log.info("활력 분석 완료 - 응답 ID: {}, 활력 수준: {}", saved.getId(), vitalityResult.getVitalityLevel());
 
         return SurveySubmissionResponseDto.builder()
             .responseId(saved.getId())

--- a/src/main/java/com/example/live_backend/domain/survey/vitality/dto/VitalityResultDto.java
+++ b/src/main/java/com/example/live_backend/domain/survey/vitality/dto/VitalityResultDto.java
@@ -1,6 +1,6 @@
 package com.example.live_backend.domain.survey.vitality.dto;
 
-import com.example.live_backend.domain.survey.vitality.enums.IsolationType;
+import com.example.live_backend.domain.survey.vitality.enums.IsolationAndSeclusionType;
 import com.example.live_backend.domain.survey.vitality.enums.VitalityLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,8 +8,8 @@ import lombok.Getter;
 @Getter
 @Builder
 public class VitalityResultDto {
-    private VitalityLevel level; // "고활력" 또는 "저활력"
-    private IsolationType isolationType; // "정서적 고립", "물리적 고립", "고립+은둔", "정상" 등
+    private VitalityLevel vitalityLevel; // "고활력" 또는 "저활력"
+    private IsolationAndSeclusionType isolationAndSeclusionType; // "정서적 고립", "물리적 고립", "고립+은둔", "정상" 등
     private boolean isIsolated; // 고립 청년 여부
     private boolean isSecluded; // 은둔 청년 여부
     private String description; // 판단 근거 설명

--- a/src/main/java/com/example/live_backend/domain/survey/vitality/enums/IsolationAndSeclusionType.java
+++ b/src/main/java/com/example/live_backend/domain/survey/vitality/enums/IsolationAndSeclusionType.java
@@ -5,11 +5,15 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum IsolationType {
+public enum IsolationAndSeclusionType {
     NORMAL("정상"),
     EMOTIONAL_ISOLATION("정서적 고립"),
     PHYSICAL_ISOLATION("물리적 고립"),
     EMOTIONAL_AND_PHYSICAL_ISOLATION("정서적+물리적 고립"),
+    EMOTIONAL_ISOLATION_AND_SECLUSION("정서적 고립 + 은둔"),
+    PHYSICAL_ISOLATION_AND_SECLUSION("물리적 고립 + 은둔"),
+    EMOTIONAL_ISOLATION_AND_PHYSICAL_ISOLATION_AND_SECLUSION("정서적, 물리적 고립 + 은둔"),
+
     ISOLATION_AND_SECLUSION("고립+은둔");
 
     private final String description;

--- a/src/main/java/com/example/live_backend/domain/survey/vitality/service/VitalityService.java
+++ b/src/main/java/com/example/live_backend/domain/survey/vitality/service/VitalityService.java
@@ -4,7 +4,7 @@ import com.example.live_backend.domain.survey.entity.SurveyAnswer;
 import com.example.live_backend.domain.survey.entity.SurveyResponse;
 import com.example.live_backend.domain.survey.repository.SurveyResponseRepository;
 import com.example.live_backend.domain.survey.vitality.dto.VitalityResultDto;
-import com.example.live_backend.domain.survey.vitality.enums.IsolationType;
+import com.example.live_backend.domain.survey.vitality.enums.IsolationAndSeclusionType;
 import com.example.live_backend.domain.survey.vitality.enums.VitalityLevel;
 import com.example.live_backend.global.error.exception.CustomException;
 import com.example.live_backend.global.error.exception.ErrorCode;
@@ -41,34 +41,50 @@ public class VitalityService {
         boolean isIsolated = (emotionalIsolation || physicalIsolation) && isDurationLongTerm(response, 9);
 
         // 4. 은둔 청년 판단: 복합 조건
-        boolean isSecluded = isSecludedYouth(response);
+        boolean isSecluded = isSecluded(response);
 
-        // 5. 활력 판단
         VitalityLevel vitalityLevel;
-        IsolationType isolationType;
-        String description;
+        IsolationAndSeclusionType isolationAndSeclusionType;
 
         if (!isIsolated) {
+            // 고립이 아니라면 -> 정상
             vitalityLevel = VitalityLevel.NORMAL;
-            isolationType = IsolationType.NORMAL;
-            description = "고립 또는 은둔 상태가 아닙니다.";
-        } else if (isIsolated && !isSecluded) {
-            vitalityLevel = VitalityLevel.HIGH_VITALITY;
-            isolationType = getIsolationTypeEnum(emotionalIsolation, physicalIsolation);
-            description = "고립 상태이지만 은둔 상태는 아니므로 고활력으로 판단됩니다.";
+            isolationAndSeclusionType = IsolationAndSeclusionType.NORMAL;
         } else {
-            vitalityLevel = VitalityLevel.LOW_VITALITY;
-            isolationType = IsolationType.ISOLATION_AND_SECLUSION;
-            description = "고립과 은둔 상태가 모두 해당되므로 저활력으로 판단됩니다.";
+            // 고립 상태일 때, 은둔 여부에 따라 활력 레벨 결정
+            vitalityLevel = isSecluded ? VitalityLevel.LOW_VITALITY : VitalityLevel.HIGH_VITALITY;
+
+            isolationAndSeclusionType = determineIsolationAndSeclusionType(emotionalIsolation, physicalIsolation, isSecluded);
         }
 
         return VitalityResultDto.builder()
-                .level(vitalityLevel)
-                .isolationType(isolationType)
+                .vitalityLevel(vitalityLevel)
+                .isolationAndSeclusionType(isolationAndSeclusionType)
                 .isIsolated(isIsolated)
                 .isSecluded(isSecluded)
-                .description(description)
+                .description(isolationAndSeclusionType.getDescription())
                 .build();
+    }
+
+    private IsolationAndSeclusionType determineIsolationAndSeclusionType(
+            boolean emotionalIsolation, boolean physicalIsolation, boolean isSecluded) {
+
+        if (emotionalIsolation && physicalIsolation) {
+            return isSecluded
+                    ? IsolationAndSeclusionType.EMOTIONAL_ISOLATION_AND_PHYSICAL_ISOLATION_AND_SECLUSION
+                    : IsolationAndSeclusionType.EMOTIONAL_AND_PHYSICAL_ISOLATION;
+        } else if (emotionalIsolation) {
+            return isSecluded
+                    ? IsolationAndSeclusionType.EMOTIONAL_ISOLATION_AND_SECLUSION
+                    : IsolationAndSeclusionType.EMOTIONAL_ISOLATION;
+        } else if (physicalIsolation) {
+            return isSecluded
+                    ? IsolationAndSeclusionType.PHYSICAL_ISOLATION_AND_SECLUSION
+                    : IsolationAndSeclusionType.PHYSICAL_ISOLATION;
+        }
+
+        // 여기에 도달하면 안 됨 (isIsolated가 true인 경우에만 호출되므로)
+        return IsolationAndSeclusionType.NORMAL;
     }
 
     // 정서적 고립: 1~4번 문항 중 하나라도 4번(없음)만 선택
@@ -97,7 +113,7 @@ public class VitalityService {
     }
 
     // 은둔 청년 판단: 10번(4~7번) + 11번(3~5번) + 12번(3번) + 13번(2번)
-    private boolean isSecludedYouth(SurveyResponse response) {
+    private boolean isSecluded(SurveyResponse response) {
         int answer10 = getAnswerNumber(response, 10);
         int answer11 = getAnswerNumber(response, 11);
         int answer12 = getAnswerNumber(response, 12);
@@ -107,18 +123,6 @@ public class VitalityService {
                 (answer11 >= 3 && answer11 <= 5) && // 11번: 3~5번
                 (answer12 == 3) &&                  // 12번: 3번
                 (answer13 == 2);                    // 13번: 2번
-    }
-
-    // 고립 유형 enum 반환
-    private IsolationType getIsolationTypeEnum(boolean emotional, boolean physical) {
-        if (emotional && physical) {
-            return IsolationType.EMOTIONAL_AND_PHYSICAL_ISOLATION;
-        } else if (emotional) {
-            return IsolationType.EMOTIONAL_ISOLATION;
-        } else if (physical) {
-            return IsolationType.PHYSICAL_ISOLATION;
-        }
-        return IsolationType.NORMAL;
     }
 
     // 필수 문항 존재 여부 확인 (1~13번)

--- a/src/main/java/com/example/live_backend/global/config/SurveyDataInitializer.java
+++ b/src/main/java/com/example/live_backend/global/config/SurveyDataInitializer.java
@@ -19,7 +19,7 @@ public class SurveyDataInitializer implements ApplicationRunner {
     @Override
     @Transactional
     @Profile({"dev", "local"}) // test 환경에서는 실행 안됨
-    public void run(ApplicationArguments args) throws Exception {
+    public void run(ApplicationArguments    args) throws Exception {
 
         if (surveyQuestionRepository.count() > 0) {
             return;

--- a/src/main/java/com/example/live_backend/global/config/SurveyDataInitializer.java
+++ b/src/main/java/com/example/live_backend/global/config/SurveyDataInitializer.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
+@Profile("!test")
 public class SurveyDataInitializer implements ApplicationRunner {
 
     private final SurveyQuestionRepository surveyQuestionRepository;

--- a/src/main/java/com/example/live_backend/global/config/SurveyDataInitializer.java
+++ b/src/main/java/com/example/live_backend/global/config/SurveyDataInitializer.java
@@ -34,53 +34,64 @@ public class SurveyDataInitializer implements ApplicationRunner {
 
         // 문항 1: 조언을 구할 수 있는 사람
         createQuestionWithOptions(1,
-                "중요하거나 어려운 일이 있을 때 조언을 구할 수 있는 사람이 있나요?",
+                "중요하거나 어려운 일이 있을 때 주로 누구에게 조언을 구하나요?",
+                SurveyQuestion.QuestionType.SINGLE_CHOICE,
                 "가족, 친척", "친구", "기타 타인 (이웃, 직장동료 등)", "없음");
 
         // 문항 2: 급한 일을 부탁할 사람
         createQuestionWithOptions(2,
-                "급한 일을 부탁할 사람이 있나요?",
+                "급한 일이 생겼을 때 주로 누구에게 부탁하나요?",
+                SurveyQuestion.QuestionType.SINGLE_CHOICE,
                 "가족, 친척", "친구", "기타 타인 (이웃, 직장동료 등)", "없음");
 
         // 문항 3: 돈을 빌릴 사람
         createQuestionWithOptions(3,
-                "돈을 빌려야 할 때 부탁할 사람이 있나요?",
+                "돈을 빌려야 할 때 주로 누구에게 부탁하나요?",
+                SurveyQuestion.QuestionType.SINGLE_CHOICE,
                 "가족, 친척", "친구", "기타 타인 (이웃, 직장동료 등)", "없음");
 
         // 문항 4: 속마음을 털어놓을 사람
         createQuestionWithOptions(4,
-                "속마음을 털어놓고 얘기할 사람이 있나요?",
+                "속마음을 털어놓고 싶을 때 주로 누구에게 얘기하나요?",
+                SurveyQuestion.QuestionType.SINGLE_CHOICE,
                 "가족, 친척", "친구", "기타 타인 (이웃, 직장동료 등)", "없음");
 
         // 문항 5: 가족 대면 교류 주기
         createQuestionWithOptions(5,
                 "가족들과의 대면 교류 주기는 어떻게 되나요?",
+                SurveyQuestion.QuestionType.SINGLE_CHOICE,
                 "전혀, 거의 없다", "몇 개월에 한 번", "한 달에 한 번", "일주일에 한 번", "일주일에 여러 번");
 
         // 문항 6: 친인척 대면 교류 주기
         createQuestionWithOptions(6,
                 "친인척들과의 대면 교류 주기는 어떻게 되나요?",
+                SurveyQuestion.QuestionType.SINGLE_CHOICE,
                 "전혀, 거의 없다", "몇 개월에 한 번", "한 달에 한 번", "일주일에 한 번", "일주일에 여러 번");
 
         // 문항 7: 친한 친구/지인 교류 주기
         createQuestionWithOptions(7,
                 "친한 친구/지인 교류 주기는 어떻게 되나요?",
+                SurveyQuestion.QuestionType.SINGLE_CHOICE,
                 "전혀, 거의 없다", "몇 개월에 한 번", "한 달에 한 번", "일주일에 한 번", "일주일에 여러 번");
 
         // 문항 8: 직장·학교·동네 지인 교류 주기
         createQuestionWithOptions(8,
                 "직장·학교·동네 지인 교류 (업무 제외) 주기는 어떻게 되나요?",
+                SurveyQuestion.QuestionType.SINGLE_CHOICE,
                 "전혀, 거의 없다", "몇 개월에 한 번", "한 달에 한 번", "일주일에 한 번", "일주일에 여러 번");
 
         // 문항 9: 상태 지속 기간
         createQuestionWithOptions(9,
                 "위의 1~8번에서 응답한 본인의 상태의 지속 기간이 어떻게 되나요?",
-                "3개월 미만", "3개월 이상 ~ 6개월 미만", "6개월 이상 ~ 1년 미만",
-                "1년 이상 ~ 3년 미만", "3년 이상");
+                SurveyQuestion.QuestionType.SINGLE_CHOICE,
+                "3개월 미만", "3개월 이상 ~ 6개월 미만", "6개월 이상 ~ 1년 미만", "1년 이상 ~ 3년 미만", "3년 이상");
+
+        // === 은둔 청년 판별 문항 (10~13번) ===
 
         // 문항 10: 외출 빈도
         createQuestionWithOptions(10,
                 "여러분은 평소에 얼마나 자주 외출하시나요?",
+                SurveyQuestion.QuestionType.SINGLE_CHOICE,
                 "직장이나 학교로 평일은 자주 외출한다",
                 "여가생활을 위해 자주 외출한다",
                 "사람을 만나기 위해 가끔 외출한다",
@@ -89,30 +100,34 @@ public class SurveyDataInitializer implements ApplicationRunner {
                 "본인 방에서 나오지만, 집 밖으로는 나가지 않는다",
                 "본인 방에서 거의 나오지 않는다");
 
-        // === 은둔 청년 판별 문항 (10~13번) ===
-
         // 문항 11: 해당 생활 지속 기간
         createQuestionWithOptions(11,
                 "위 10번 응답에 대한 생활을 한 지 얼마나 되셨나요?",
+                SurveyQuestion.QuestionType.SINGLE_CHOICE,
                 "3개월 미만", "3개월 이상 ~ 6개월 미만", "6개월 이상 ~ 1년 미만", "1년 이상 ~ 3년 미만", "3년 이상");
 
         // 문항 12: 경제활동 여부
         createQuestionWithOptions(12,
                 "최근 일주일 간 돈을 벌기 위한 경제활동을 하셨나요? 시간은 상관없습니다.",
+                SurveyQuestion.QuestionType.SINGLE_CHOICE,
                 "일을 하였다", "휴가 및 일시 휴직 중이다", "일을 하지 않았다");
 
         // 문항 13: 구직 활동 여부
         createQuestionWithOptions(13,
                 "만약 경제활동을 하지 않았다면 지난 한 달간 구직 활동을 하셨나요?",
+                SurveyQuestion.QuestionType.SINGLE_CHOICE,
                 "구직 활동을 하였다", "구직 활동을 하지 않았다");
     }
 
-    private void createQuestionWithOptions(int questionNumber, String questionText, String... optionTexts) {
+    private void createQuestionWithOptions(int questionNumber,
+                                           String questionText,
+                                           SurveyQuestion.QuestionType questionType,
+                                           String... optionTexts) {
 
         SurveyQuestion question = SurveyQuestion.builder()
                 .questionNumber(questionNumber)
                 .questionText(questionText)
-                .questionType(SurveyQuestion.QuestionType.MULTIPLE_CHOICE)
+                .questionType(questionType)
                 .isRequired(true)
                 .isActive(true)
                 .build();

--- a/src/main/java/com/example/live_backend/global/config/SurveyDataInitializer.java
+++ b/src/main/java/com/example/live_backend/global/config/SurveyDataInitializer.java
@@ -1,0 +1,130 @@
+package com.example.live_backend.global.config;
+
+import com.example.live_backend.domain.survey.entity.SurveyQuestion;
+import com.example.live_backend.domain.survey.entity.SurveyQuestionOption;
+import com.example.live_backend.domain.survey.repository.SurveyQuestionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class SurveyDataInitializer implements ApplicationRunner {
+
+    private final SurveyQuestionRepository surveyQuestionRepository;
+
+    @Override
+    @Transactional
+    @Profile({"dev", "local"}) // test 환경에서는 실행 안됨
+    public void run(ApplicationArguments args) throws Exception {
+
+        if (surveyQuestionRepository.count() > 0) {
+            return;
+        }
+
+        initializeSurveyQuestions();
+    }
+
+    private void initializeSurveyQuestions() {
+
+        // === 고립 청년 판별 문항 (1~9번) ===
+
+        // 문항 1: 조언을 구할 수 있는 사람
+        createQuestionWithOptions(1,
+                "중요하거나 어려운 일이 있을 때 조언을 구할 수 있는 사람이 있나요?",
+                "가족, 친척", "친구", "기타 타인 (이웃, 직장동료 등)", "없음");
+
+        // 문항 2: 급한 일을 부탁할 사람
+        createQuestionWithOptions(2,
+                "급한 일을 부탁할 사람이 있나요?",
+                "가족, 친척", "친구", "기타 타인 (이웃, 직장동료 등)", "없음");
+
+        // 문항 3: 돈을 빌릴 사람
+        createQuestionWithOptions(3,
+                "돈을 빌려야 할 때 부탁할 사람이 있나요?",
+                "가족, 친척", "친구", "기타 타인 (이웃, 직장동료 등)", "없음");
+
+        // 문항 4: 속마음을 털어놓을 사람
+        createQuestionWithOptions(4,
+                "속마음을 털어놓고 얘기할 사람이 있나요?",
+                "가족, 친척", "친구", "기타 타인 (이웃, 직장동료 등)", "없음");
+
+        // 문항 5: 가족 대면 교류 주기
+        createQuestionWithOptions(5,
+                "가족들과의 대면 교류 주기는 어떻게 되나요?",
+                "전혀, 거의 없다", "몇 개월에 한 번", "한 달에 한 번", "일주일에 한 번", "일주일에 여러 번");
+
+        // 문항 6: 친인척 대면 교류 주기
+        createQuestionWithOptions(6,
+                "친인척들과의 대면 교류 주기는 어떻게 되나요?",
+                "전혀, 거의 없다", "몇 개월에 한 번", "한 달에 한 번", "일주일에 한 번", "일주일에 여러 번");
+
+        // 문항 7: 친한 친구/지인 교류 주기
+        createQuestionWithOptions(7,
+                "친한 친구/지인 교류 주기는 어떻게 되나요?",
+                "전혀, 거의 없다", "몇 개월에 한 번", "한 달에 한 번", "일주일에 한 번", "일주일에 여러 번");
+
+        // 문항 8: 직장·학교·동네 지인 교류 주기
+        createQuestionWithOptions(8,
+                "직장·학교·동네 지인 교류 (업무 제외) 주기는 어떻게 되나요?",
+                "전혀, 거의 없다", "몇 개월에 한 번", "한 달에 한 번", "일주일에 한 번", "일주일에 여러 번");
+
+        // 문항 9: 상태 지속 기간
+        createQuestionWithOptions(9,
+                "위의 1~8번에서 응답한 본인의 상태의 지속 기간이 어떻게 되나요?",
+                "3개월 미만", "3개월 이상 ~ 6개월 미만", "6개월 이상 ~ 1년 미만",
+                "1년 이상 ~ 3년 미만", "3년 이상");
+
+        // 문항 10: 외출 빈도
+        createQuestionWithOptions(10,
+                "여러분은 평소에 얼마나 자주 외출하시나요?",
+                "직장이나 학교로 평일은 자주 외출한다",
+                "여가생활을 위해 자주 외출한다",
+                "사람을 만나기 위해 가끔 외출한다",
+                "보통은 집에 있지만, 자신의 취미생활만을 위해 외출한다",
+                "보통은 집에 있지만, 인근 편의점 등에 외출한다",
+                "본인 방에서 나오지만, 집 밖으로는 나가지 않는다",
+                "본인 방에서 거의 나오지 않는다");
+
+        // === 은둔 청년 판별 문항 (10~13번) ===
+
+        // 문항 11: 해당 생활 지속 기간
+        createQuestionWithOptions(11,
+                "위 10번 응답에 대한 생활을 한 지 얼마나 되셨나요?",
+                "3개월 미만", "3개월 이상 ~ 6개월 미만", "6개월 이상 ~ 1년 미만", "1년 이상 ~ 3년 미만", "3년 이상");
+
+        // 문항 12: 경제활동 여부
+        createQuestionWithOptions(12,
+                "최근 일주일 간 돈을 벌기 위한 경제활동을 하셨나요? 시간은 상관없습니다.",
+                "일을 하였다", "휴가 및 일시 휴직 중이다", "일을 하지 않았다");
+
+        // 문항 13: 구직 활동 여부
+        createQuestionWithOptions(13,
+                "만약 경제활동을 하지 않았다면 지난 한 달간 구직 활동을 하셨나요?",
+                "구직 활동을 하였다", "구직 활동을 하지 않았다");
+    }
+
+    private void createQuestionWithOptions(int questionNumber, String questionText, String... optionTexts) {
+
+        SurveyQuestion question = SurveyQuestion.builder()
+                .questionNumber(questionNumber)
+                .questionText(questionText)
+                .questionType(SurveyQuestion.QuestionType.MULTIPLE_CHOICE)
+                .isRequired(true)
+                .isActive(true)
+                .build();
+
+        for (int i = 0; i < optionTexts.length; i++) {
+            question.addOption(SurveyQuestionOption.builder()
+                    .optionNumber(i + 1)
+                    .optionText(optionTexts[i])
+                    .isActive(true)
+                    .build());
+        }
+
+        surveyQuestionRepository.save(question);
+    }
+}

--- a/src/test/java/com/example/live_backend/domain/survey/service/SurveyServiceTest.java
+++ b/src/test/java/com/example/live_backend/domain/survey/service/SurveyServiceTest.java
@@ -1,7 +1,7 @@
 package com.example.live_backend.domain.survey.service;
 
 import com.example.live_backend.domain.survey.vitality.dto.VitalityResultDto;
-import com.example.live_backend.domain.survey.vitality.enums.IsolationType;
+import com.example.live_backend.domain.survey.vitality.enums.IsolationAndSeclusionType;
 import com.example.live_backend.domain.survey.vitality.enums.VitalityLevel;
 import com.example.live_backend.domain.survey.vitality.service.VitalityService;
 import com.example.live_backend.global.error.exception.CustomException;
@@ -226,8 +226,8 @@ class SurveyServiceTest {
 			given(surveyResponseRepository.save(any(SurveyResponse.class))).willReturn(savedResponse);
 
 			VitalityResultDto mockResult = VitalityResultDto.builder()
-					.level(VitalityLevel.NORMAL)
-					.isolationType(IsolationType.NORMAL)
+					.vitalityLevel(VitalityLevel.NORMAL)
+					.isolationAndSeclusionType(IsolationAndSeclusionType.NORMAL)
 					.isIsolated(false)
 					.isSecluded(false)
 					.description("정상")
@@ -540,8 +540,8 @@ class SurveyServiceTest {
 				});
 
 			VitalityResultDto mockResult = VitalityResultDto.builder()
-					.level(VitalityLevel.NORMAL)
-					.isolationType(IsolationType.NORMAL)
+					.vitalityLevel(VitalityLevel.NORMAL)
+					.isolationAndSeclusionType(IsolationAndSeclusionType.NORMAL)
 					.isIsolated(false)
 					.isSecluded(false)
 					.description("정상")

--- a/src/test/java/com/example/live_backend/domain/survey/vitality/service/VitalityServiceTest.java
+++ b/src/test/java/com/example/live_backend/domain/survey/vitality/service/VitalityServiceTest.java
@@ -36,6 +36,7 @@ class VitalityServiceTest {
 
     @Mock
     private SurveyResponseRepository surveyResponseRepository;
+    
 
     @Test
     @DisplayName("고립 또는 은둔이 아닐 경우 '정상'을 반환한다")
@@ -126,6 +127,119 @@ class VitalityServiceTest {
         // when & then
         CustomException exception = assertThrows(CustomException.class, () -> vitalityService.analyzeVitality(responseId));
         assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.SURVEY_RESPONSE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("물리적 고립만 해당될 경우 '고활력 + 물리적 고립'을 반환한다")
+    void analyzeVitality_PhysicalIsolationOnly_HighVitality() {
+        // given
+        Long responseId = 5L;
+        Map<Integer, Integer> answers = createAnswers(false, true, true, false);
+        SurveyResponse mockResponse = createMockResponse(answers);
+        when(surveyResponseRepository.findById(responseId)).thenReturn(Optional.of(mockResponse));
+
+        // when
+        VitalityResultDto result = vitalityService.analyzeVitality(responseId);
+
+        // then
+        assertThat(result.getVitalityLevel()).isEqualTo(VitalityLevel.HIGH_VITALITY);
+        assertThat(result.getIsolationAndSeclusionType()).isEqualTo(IsolationAndSeclusionType.PHYSICAL_ISOLATION);
+        assertThat(result.isIsolated()).isTrue();
+        assertThat(result.isSecluded()).isFalse();
+    }
+
+    @Test
+    @DisplayName("정서적 + 물리적 고립 모두 해당될 경우 '고활력 + 정서적/물리적 고립'을 반환한다")
+    void analyzeVitality_BothIsolation_HighVitality() {
+        // given
+        Long responseId = 6L;
+        Map<Integer, Integer> answers = createAnswers(true, true, true, false);
+        SurveyResponse mockResponse = createMockResponse(answers);
+        when(surveyResponseRepository.findById(responseId)).thenReturn(Optional.of(mockResponse));
+
+        // when
+        VitalityResultDto result = vitalityService.analyzeVitality(responseId);
+
+        // then
+        assertThat(result.getVitalityLevel()).isEqualTo(VitalityLevel.HIGH_VITALITY);
+        assertThat(result.getIsolationAndSeclusionType()).isEqualTo(IsolationAndSeclusionType.EMOTIONAL_AND_PHYSICAL_ISOLATION);
+        assertThat(result.isIsolated()).isTrue();
+        assertThat(result.isSecluded()).isFalse();
+    }
+
+    @Test
+    @DisplayName("정서적 고립 + 은둔일 경우 '저활력 + 정서적 고립/은둔'을 반환한다")
+    void analyzeVitality_EmotionalIsolationAndSeclusion_LowVitality() {
+        // given
+        Long responseId = 7L;
+        Map<Integer, Integer> answers = createAnswers(true, true, false, true);
+        SurveyResponse mockResponse = createMockResponse(answers);
+        when(surveyResponseRepository.findById(responseId)).thenReturn(Optional.of(mockResponse));
+
+        // when
+        VitalityResultDto result = vitalityService.analyzeVitality(responseId);
+
+        // then
+        assertThat(result.getVitalityLevel()).isEqualTo(VitalityLevel.LOW_VITALITY);
+        assertThat(result.getIsolationAndSeclusionType()).isEqualTo(IsolationAndSeclusionType.EMOTIONAL_ISOLATION_AND_SECLUSION);
+        assertThat(result.isIsolated()).isTrue();
+        assertThat(result.isSecluded()).isTrue();
+    }
+
+    @Test
+    @DisplayName("정서적 + 물리적 고립 + 은둔 모두 해당될 경우 '저활력'을 반환한다")
+    void analyzeVitality_AllConditions_LowVitality() {
+        // given
+        Long responseId = 8L;
+        Map<Integer, Integer> answers = createAnswers(true, true, true, true);
+        SurveyResponse mockResponse = createMockResponse(answers);
+        when(surveyResponseRepository.findById(responseId)).thenReturn(Optional.of(mockResponse));
+
+        // when
+        VitalityResultDto result = vitalityService.analyzeVitality(responseId);
+
+        // then
+        assertThat(result.getVitalityLevel()).isEqualTo(VitalityLevel.LOW_VITALITY);
+        assertThat(result.getIsolationAndSeclusionType())
+                .isEqualTo(IsolationAndSeclusionType.EMOTIONAL_ISOLATION_AND_PHYSICAL_ISOLATION_AND_SECLUSION);
+        assertThat(result.isIsolated()).isTrue();
+        assertThat(result.isSecluded()).isTrue();
+    }
+
+    @Test
+    @DisplayName("고립 조건이지만 장기화(6개월 이상)가 아니면 '정상'을 반환한다")
+    void analyzeVitality_IsolationWithoutLongTerm_ReturnsNormal() {
+        // given
+        Long responseId = 9L;
+        Map<Integer, Integer> answers = createAnswers(true, false, false, false);
+        SurveyResponse mockResponse = createMockResponse(answers);
+        when(surveyResponseRepository.findById(responseId)).thenReturn(Optional.of(mockResponse));
+
+        // when
+        VitalityResultDto result = vitalityService.analyzeVitality(responseId);
+
+        // then
+        assertThat(result.getVitalityLevel()).isEqualTo(VitalityLevel.NORMAL);
+        assertThat(result.getIsolationAndSeclusionType()).isEqualTo(IsolationAndSeclusionType.NORMAL);
+        assertThat(result.isIsolated()).isFalse();
+    }
+
+    @Test
+    @DisplayName("은둔 조건만 충족하고 고립이 아니면 '정상'을 반환한다")
+    void analyzeVitality_SeclusionOnlyWithoutIsolation_ReturnsNormal() {
+        // given
+        Long responseId = 10L;
+        Map<Integer, Integer> answers = createAnswers(false, false, false, true);
+        SurveyResponse mockResponse = createMockResponse(answers);
+        when(surveyResponseRepository.findById(responseId)).thenReturn(Optional.of(mockResponse));
+
+        // when
+        VitalityResultDto result = vitalityService.analyzeVitality(responseId);
+
+        // then
+        assertThat(result.getVitalityLevel()).isEqualTo(VitalityLevel.NORMAL);
+        assertThat(result.isIsolated()).isFalse();
+        assertThat(result.isSecluded()).isTrue();
     }
 
     private SurveyResponse createMockResponse(Map<Integer, Integer> answerMap) {

--- a/src/test/java/com/example/live_backend/domain/survey/vitality/service/VitalityServiceTest.java
+++ b/src/test/java/com/example/live_backend/domain/survey/vitality/service/VitalityServiceTest.java
@@ -4,7 +4,7 @@ import com.example.live_backend.domain.survey.entity.SurveyAnswer;
 import com.example.live_backend.domain.survey.entity.SurveyResponse;
 import com.example.live_backend.domain.survey.repository.SurveyResponseRepository;
 import com.example.live_backend.domain.survey.vitality.dto.VitalityResultDto;
-import com.example.live_backend.domain.survey.vitality.enums.IsolationType;
+import com.example.live_backend.domain.survey.vitality.enums.IsolationAndSeclusionType;
 import com.example.live_backend.domain.survey.vitality.enums.VitalityLevel;
 import com.example.live_backend.global.error.exception.CustomException;
 import com.example.live_backend.global.error.exception.ErrorCode;
@@ -51,8 +51,8 @@ class VitalityServiceTest {
         VitalityResultDto result = vitalityService.analyzeVitality(responseId);
 
         // then
-        assertThat(result.getLevel()).isEqualTo(VitalityLevel.NORMAL);
-        assertThat(result.getIsolationType()).isEqualTo(IsolationType.NORMAL);
+        assertThat(result.getVitalityLevel()).isEqualTo(VitalityLevel.NORMAL);
+        assertThat(result.getIsolationAndSeclusionType()).isEqualTo(IsolationAndSeclusionType.NORMAL);
         assertThat(result.isIsolated()).isFalse();
         assertThat(result.isSecluded()).isFalse();
     }
@@ -73,8 +73,8 @@ class VitalityServiceTest {
         VitalityResultDto result = vitalityService.analyzeVitality(responseId);
 
         // then
-        assertThat(result.getLevel()).isEqualTo(VitalityLevel.HIGH_VITALITY);
-        assertThat(result.getIsolationType()).isEqualTo(IsolationType.EMOTIONAL_ISOLATION);
+        assertThat(result.getVitalityLevel()).isEqualTo(VitalityLevel.HIGH_VITALITY);
+        assertThat(result.getIsolationAndSeclusionType()).isEqualTo(IsolationAndSeclusionType.EMOTIONAL_ISOLATION);
         assertThat(result.isIsolated()).isTrue();
         assertThat(result.isSecluded()).isFalse();
     }
@@ -94,8 +94,8 @@ class VitalityServiceTest {
         VitalityResultDto result = vitalityService.analyzeVitality(responseId);
 
         // then
-        assertThat(result.getLevel()).isEqualTo(VitalityLevel.LOW_VITALITY);
-        assertThat(result.getIsolationType()).isEqualTo(IsolationType.ISOLATION_AND_SECLUSION);
+        assertThat(result.getVitalityLevel()).isEqualTo(VitalityLevel.LOW_VITALITY);
+        assertThat(result.getIsolationAndSeclusionType()).isEqualTo(IsolationAndSeclusionType.PHYSICAL_ISOLATION_AND_SECLUSION);
         assertThat(result.isIsolated()).isTrue();
         assertThat(result.isSecluded()).isTrue();
     }

--- a/src/test/java/com/example/live_backend/global/config/SurveyDataInitializerTest.java
+++ b/src/test/java/com/example/live_backend/global/config/SurveyDataInitializerTest.java
@@ -1,0 +1,223 @@
+package com.example.live_backend.global.config;
+
+import com.example.live_backend.domain.survey.entity.SurveyQuestion;
+import com.example.live_backend.domain.survey.repository.SurveyQuestionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SurveyDataInitializer 테스트")
+class SurveyDataInitializerTest {
+
+    @Mock
+    private SurveyQuestionRepository surveyQuestionRepository;
+
+    @InjectMocks
+    private SurveyDataInitializer surveyDataInitializer;
+
+    @Captor
+    private ArgumentCaptor<SurveyQuestion> questionCaptor;
+
+    @Nested
+    @DisplayName("초기화 실행 조건 테스트")
+    class InitializationConditionTests {
+
+        @Test
+        @DisplayName("데이터가 없을 때 초기화가 실행된다")
+        void whenNoDataExists_thenInitializationRuns() throws Exception {
+            // given
+            given(surveyQuestionRepository.count()).willReturn(0L);
+
+            // when
+            surveyDataInitializer.run(null);
+
+            // then
+            verify(surveyQuestionRepository, times(13)).save(any(SurveyQuestion.class));
+        }
+
+        @Test
+        @DisplayName("데이터가 이미 있을 때 초기화를 건너뛴다")
+        void whenDataExists_thenInitializationSkipped() throws Exception {
+            // given
+            given(surveyQuestionRepository.count()).willReturn(1L);
+
+            // when
+            surveyDataInitializer.run(null);
+
+            // then
+            verify(surveyQuestionRepository, never()).save(any(SurveyQuestion.class));
+        }
+
+        @Test
+        @DisplayName("데이터가 여러 개 있을 때도 초기화를 건너뛴다")
+        void whenMultipleDataExists_thenInitializationSkipped() throws Exception {
+            // given
+            given(surveyQuestionRepository.count()).willReturn(13L);
+
+            // when
+            surveyDataInitializer.run(null);
+
+            // then
+            verify(surveyQuestionRepository, never()).save(any(SurveyQuestion.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("문항 삽입 검증 테스트")
+    class QuestionInsertionTests {
+
+        @BeforeEach
+        void setUp() {
+            given(surveyQuestionRepository.count()).willReturn(0L);
+        }
+
+        @Test
+        @DisplayName("13개의 설문 문항이 삽입된다")
+        void shouldInsert13Questions() throws Exception {
+            // when
+            surveyDataInitializer.run(null);
+
+            // then
+            verify(surveyQuestionRepository, times(13)).save(questionCaptor.capture());
+            List<SurveyQuestion> savedQuestions = questionCaptor.getAllValues();
+            assertThat(savedQuestions).hasSize(13);
+        }
+
+        @Test
+        @DisplayName("문항 번호가 1부터 13까지 순서대로 삽입된다")
+        void shouldInsertQuestionsInOrder() throws Exception {
+            // when
+            surveyDataInitializer.run(null);
+
+            // then
+            verify(surveyQuestionRepository, times(13)).save(questionCaptor.capture());
+            List<SurveyQuestion> savedQuestions = questionCaptor.getAllValues();
+
+            for (int i = 0; i < 13; i++) {
+                assertThat(savedQuestions.get(i).getQuestionNumber()).isEqualTo(i + 1);
+            }
+        }
+
+        @Test
+        @DisplayName("각 문항에 올바른 개수의 옵션이 포함된다")
+        void shouldHaveCorrectOptionCounts() throws Exception {
+            // given
+            // 1~4번: 4개, 5~9번: 5개, 10번: 7개, 11번: 5개, 12번: 3개, 13번: 2개
+            int[] expectedOptionCounts = {4, 4, 4, 4, 5, 5, 5, 5, 5, 7, 5, 3, 2};
+
+            // when
+            surveyDataInitializer.run(null);
+
+            // then
+            verify(surveyQuestionRepository, times(13)).save(questionCaptor.capture());
+            List<SurveyQuestion> savedQuestions = questionCaptor.getAllValues();
+
+            for (int i = 0; i < 13; i++) {
+                assertThat(savedQuestions.get(i).getOptions())
+                        .hasSize(expectedOptionCounts[i])
+                        .as("문항 %d의 옵션 개수", i + 1);
+            }
+        }
+
+        @Test
+        @DisplayName("모든 문항이 필수(isRequired=true)로 설정된다")
+        void allQuestionsShouldBeRequired() throws Exception {
+            // when
+            surveyDataInitializer.run(null);
+
+            // then
+            verify(surveyQuestionRepository, times(13)).save(questionCaptor.capture());
+            List<SurveyQuestion> savedQuestions = questionCaptor.getAllValues();
+
+            assertThat(savedQuestions)
+                    .allMatch(SurveyQuestion::isRequired);
+        }
+
+        @Test
+        @DisplayName("모든 문항이 활성화(isActive=true) 상태로 설정된다")
+        void allQuestionsShouldBeActive() throws Exception {
+            // when
+            surveyDataInitializer.run(null);
+
+            // then
+            verify(surveyQuestionRepository, times(13)).save(questionCaptor.capture());
+            List<SurveyQuestion> savedQuestions = questionCaptor.getAllValues();
+
+            assertThat(savedQuestions)
+                    .allMatch(SurveyQuestion::isActive);
+        }
+    }
+
+    @Nested
+    @DisplayName("문항 내용 검증 테스트")
+    class QuestionContentTests {
+
+        @BeforeEach
+        void setUp() {
+            given(surveyQuestionRepository.count()).willReturn(0L);
+        }
+
+        @Test
+        @DisplayName("1번 문항이 올바른 텍스트를 가진다")
+        void question1ShouldHaveCorrectText() throws Exception {
+            // when
+            surveyDataInitializer.run(null);
+
+            // then
+            verify(surveyQuestionRepository, times(13)).save(questionCaptor.capture());
+            SurveyQuestion question1 = questionCaptor.getAllValues().get(0);
+
+            assertThat(question1.getQuestionText())
+                    .contains("중요하거나 어려운 일이 있을 때 주로 누구에게 조언을 구하나요?");
+        }
+
+        @Test
+        @DisplayName("1~4번 문항의 마지막 옵션이 '없음'이다")
+        void questions1to4ShouldHaveNoOptionAsLast() throws Exception {
+            // when
+            surveyDataInitializer.run(null);
+
+            // then
+            verify(surveyQuestionRepository, times(13)).save(questionCaptor.capture());
+            List<SurveyQuestion> savedQuestions = questionCaptor.getAllValues();
+
+            for (int i = 0; i < 4; i++) {
+                SurveyQuestion question = savedQuestions.get(i);
+                String lastOptionText = question.getOptions()
+                        .get(question.getOptions().size() - 1)
+                        .getOptionText();
+
+                assertThat(lastOptionText)
+                        .isEqualTo("없음")
+                        .as("문항 %d의 마지막 옵션", i + 1);
+            }
+        }
+
+        @Test
+        @DisplayName("10번 문항(외출 빈도)이 7개의 옵션을 가진다")
+        void question10ShouldHave7Options() throws Exception {
+            // when
+            surveyDataInitializer.run(null);
+
+            // then
+            verify(surveyQuestionRepository, times(13)).save(questionCaptor.capture());
+            SurveyQuestion question10 = questionCaptor.getAllValues().get(9);
+
+            assertThat(question10.getOptions()).hasSize(7);
+            assertThat(question10.getQuestionText()).contains("외출");
+        }
+    }
+}


### PR DESCRIPTION
### ✅ PR 타입 (하나 이상 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [x] 리팩토링 / 코드 개선
- [ ] 의존성 / 환경 설정 변경
- [ ] 버그 수정
- [ ] 기타 (하단에 설명)

&nbsp;

### ✨ 어떤 내용인가요?

> 서버 시작 시 설문 문항(13개)을 자동으로 초기화하는 `SurveyDataInitializer`를 추가했습니다.

&nbsp;

### 🔍 작업 상세 내용

- [x] `SurveyDataInitializer` 구현
    - `ApplicationRunner` 구현체로 서버 시작 시 자동 실행
    - `count() > 0` 조건으로 중복 삽입 방지
    - `@Profile({"dev", "local"})` 적용으로 test 프로파일에서는 실행안되도록 조치

- [x] 설문 문항 13개 + 옵션 초기화
    - 1~4번: 정서적 고립 판별 문항 
    - 5~9번: 물리적 고립 판별 문항 
    - 10~13번: 은둔 청년 판별 문항

- [x] `data.sql` 대신 `ApplicationRunner` 선택
    - 컴파일 타임에 검증 가능 (SQL 에러를 피할 수 있음)
    - `addOption()` 메서드로 자연스럽게 처리 (vs ID 하드코딩/서브쿼리 안날려도 됨)
    - `@Profile` 어노테이션으로 환경별 분리 가능
    - `count() > 0` 로직으로 명시적 제어 (vs INSERT IGNORE)

- [x] `VitalityServiceTest` 에 테스트 추가
    - 모든 `IsolationAndSeclusionType`에 대한 테스트 케이스 추가

&nbsp;

### 💬 리뷰어에게 전달할 내용

> `SurveyDataInitializer` 사용 목적에 대해 리뷰 부탁립니다!

&nbsp;

### 🔗 관련 이슈
- Resolves: #119