### PR TITLE
[Feat/#121] 약관 동의 내용 저장, 조회 

### DIFF
--- a/src/main/java/com/example/live_backend/domain/memeber/controller/MemberController.java
+++ b/src/main/java/com/example/live_backend/domain/memeber/controller/MemberController.java
@@ -1,14 +1,12 @@
 package com.example.live_backend.domain.memeber.controller;
 
+import com.example.live_backend.domain.memeber.dto.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import com.example.live_backend.domain.memeber.controller.docs.MemberControllerDocs;
-import com.example.live_backend.domain.memeber.dto.MemberProfileRequestDto;
-import com.example.live_backend.domain.memeber.dto.MemberResponseDto;
-import com.example.live_backend.domain.memeber.dto.NicknameCheckResponseDto;
 import com.example.live_backend.domain.memeber.service.MemberService;
 import com.example.live_backend.global.error.response.ResponseHandler;
 import com.example.live_backend.global.security.PrincipalDetails;
@@ -63,4 +61,27 @@ public class MemberController implements MemberControllerDocs {
 		MemberResponseDto response = memberService.getMemberById(userId);
 		return ResponseHandler.success(response);
 	}
+
+    @Override
+    @AuthenticatedApi(reason = "약관 동의는 로그인된 사용자만 가능")
+    @PostMapping("/terms")
+    public ResponseHandler<TermsAgreementResponseDto> updateTermsAgreement(
+            @Valid @RequestBody TermsAgreementRequestDto dto,
+            @AuthenticationPrincipal PrincipalDetails userDetails
+    ) {
+        Long userId = userDetails.getMemberId();
+        TermsAgreementResponseDto response = memberService.updateTermsAgreement(dto, userId);
+        return ResponseHandler.success(response);
+    }
+
+    @Override
+    @AuthenticatedApi(reason = "약관 동의 상태 조회는 로그인된 사용자만 가능")
+    @GetMapping("/terms")
+    public ResponseHandler<TermsAgreementResponseDto> getTermsAgreement(
+            @AuthenticationPrincipal PrincipalDetails userDetails
+    ) {
+        Long userId = userDetails.getMemberId();
+        TermsAgreementResponseDto response = memberService.getTermsAgreement(userId);
+        return ResponseHandler.success(response);
+    }
 }

--- a/src/main/java/com/example/live_backend/domain/memeber/controller/docs/MemberControllerDocs.java
+++ b/src/main/java/com/example/live_backend/domain/memeber/controller/docs/MemberControllerDocs.java
@@ -1,8 +1,6 @@
 package com.example.live_backend.domain.memeber.controller.docs;
 
-import com.example.live_backend.domain.memeber.dto.MemberProfileRequestDto;
-import com.example.live_backend.domain.memeber.dto.MemberResponseDto;
-import com.example.live_backend.domain.memeber.dto.NicknameCheckResponseDto;
+import com.example.live_backend.domain.memeber.dto.*;
 import com.example.live_backend.global.error.response.ResponseHandler;
 import com.example.live_backend.global.security.PrincipalDetails;
 import io.swagger.v3.oas.annotations.Operation;
@@ -182,5 +180,54 @@ public interface MemberControllerDocs {
     })
     ResponseHandler<MemberResponseDto> getMyProfile(
         @AuthenticationPrincipal PrincipalDetails userDetails
+    );
+
+    @Operation(summary = "약관 동의 등록/수정", description = "사용자의 약관 동의 상태를 등록하거나 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "약관 동의 등록/수정 성공"),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                    {
+                        "success": false,
+                        "error": {
+                            "code": "UNAUTHORIZED",
+                            "message": "인증이 필요합니다."
+                        }
+                    }
+                    """)
+                    )
+            )
+    })
+    ResponseHandler<TermsAgreementResponseDto> updateTermsAgreement(
+            @Valid @RequestBody TermsAgreementRequestDto dto,
+            @AuthenticationPrincipal PrincipalDetails userDetails
+    );
+
+    @Operation(summary = "약관 동의 상태 조회", description = "현재 로그인한 사용자의 약관 동의 상태를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "약관 동의 상태 조회 성공"),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                    {
+                        "success": false,
+                        "error": {
+                            "code": "UNAUTHORIZED",
+                            "message": "인증이 필요합니다."
+                        }
+                    }
+                    """)
+                    )
+            )
+    })
+    ResponseHandler<TermsAgreementResponseDto> getTermsAgreement(
+            @AuthenticationPrincipal PrincipalDetails userDetails
     );
 } 

--- a/src/main/java/com/example/live_backend/domain/memeber/dto/TermsAgreementRequestDto.java
+++ b/src/main/java/com/example/live_backend/domain/memeber/dto/TermsAgreementRequestDto.java
@@ -1,0 +1,17 @@
+package com.example.live_backend.domain.memeber.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class TermsAgreementRequestDto {
+
+    @NotNull(message = "서비스 이용 약관 동의 여부는 필수입니다")
+    private Boolean serviceTermsAgreed;
+
+    @NotNull(message = "개인정보 수집 동의 여부는 필수입니다")
+    private Boolean privacyPolicyAgreed;
+
+    @NotNull(message = "위치정보 이용 약관 동의 여부는 필수입니다")
+    private Boolean locationTermsAgreed;
+}

--- a/src/main/java/com/example/live_backend/domain/memeber/dto/TermsAgreementResponseDto.java
+++ b/src/main/java/com/example/live_backend/domain/memeber/dto/TermsAgreementResponseDto.java
@@ -1,0 +1,28 @@
+package com.example.live_backend.domain.memeber.dto;
+
+import com.example.live_backend.domain.memeber.entity.vo.TermsAgreement;
+import lombok.Getter;
+
+@Getter
+public class TermsAgreementResponseDto {
+
+    private boolean serviceTermsAgreed;
+    private boolean privacyPolicyAgreed;
+    private boolean locationTermsAgreed;
+
+    public TermsAgreementResponseDto(boolean serviceTermsAgreed,
+                                     boolean privacyPolicyAgreed,
+                                     boolean locationTermsAgreed) {
+        this.serviceTermsAgreed = serviceTermsAgreed;
+        this.privacyPolicyAgreed = privacyPolicyAgreed;
+        this.locationTermsAgreed = locationTermsAgreed;
+    }
+
+    public static TermsAgreementResponseDto from(TermsAgreement termsAgreement) {
+        return new TermsAgreementResponseDto(
+                termsAgreement.isServiceTermsAgreed(),
+                termsAgreement.isPrivacyPolicyAgreed(),
+                termsAgreement.isLocationTermsAgreed()
+        );
+    }
+}

--- a/src/main/java/com/example/live_backend/domain/memeber/entity/Member.java
+++ b/src/main/java/com/example/live_backend/domain/memeber/entity/Member.java
@@ -5,6 +5,7 @@ import com.example.live_backend.domain.memeber.Role;
 import com.example.live_backend.domain.memeber.entity.vo.BirthDate;
 import com.example.live_backend.domain.memeber.entity.vo.Profile;
 
+import com.example.live_backend.domain.memeber.entity.vo.TermsAgreement;
 import com.example.live_backend.domain.survey.vitality.enums.VitalityLevel;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -59,6 +60,9 @@ public class Member {
 	@Column(name = "clover_count", nullable = false)
 	private int cloverCount = 0;
 
+    @Embedded
+    private TermsAgreement termsAgreement;
+
 	@Builder
 	public Member(String oauthId,
 		String email,
@@ -77,6 +81,7 @@ public class Member {
 		this.occupation = occupation;
 		this.occupationDetail = occupationDetail;
 		this.cloverCount = 0;
+        this.termsAgreement = new TermsAgreement(false, false, false);
 	}
 
 	public void updateProfile(Profile newProfile) {
@@ -105,4 +110,8 @@ public class Member {
 	public int getCloverCount() {
 		return this.cloverCount;
 	}
+
+    public void updateTermsAgreement(TermsAgreement termsAgreement) {
+        this.termsAgreement = termsAgreement;
+    }
 }

--- a/src/main/java/com/example/live_backend/domain/memeber/entity/vo/TermsAgreement.java
+++ b/src/main/java/com/example/live_backend/domain/memeber/entity/vo/TermsAgreement.java
@@ -1,0 +1,36 @@
+package com.example.live_backend.domain.memeber.entity.vo;
+
+import com.example.live_backend.domain.memeber.dto.TermsAgreementRequestDto;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TermsAgreement {
+
+    @Column(name = "service_terms_agreed", nullable = false)
+    private boolean serviceTermsAgreed;
+
+    @Column(name = "privacy_policy_agreed", nullable = false)
+    private boolean privacyPolicyAgreed;
+
+    @Column(name = "location_terms_agreed", nullable = false)
+    private boolean locationTermsAgreed;
+
+    public TermsAgreement(boolean serviceTermsAgreed, boolean privacyPolicyAgreed, boolean locationTermsAgreed) {
+        this.serviceTermsAgreed = serviceTermsAgreed;
+        this.privacyPolicyAgreed = privacyPolicyAgreed;
+        this.locationTermsAgreed = locationTermsAgreed;
+    }
+
+    public static TermsAgreement from(TermsAgreementRequestDto dto) {
+        return new TermsAgreement(
+                dto.getServiceTermsAgreed(),
+                dto.getPrivacyPolicyAgreed(),
+                dto.getLocationTermsAgreed()
+        );
+    }}

--- a/src/main/java/com/example/live_backend/domain/memeber/service/MemberService.java
+++ b/src/main/java/com/example/live_backend/domain/memeber/service/MemberService.java
@@ -1,6 +1,8 @@
 package com.example.live_backend.domain.memeber.service;
 
 
+import com.example.live_backend.domain.memeber.dto.*;
+import com.example.live_backend.domain.memeber.entity.vo.TermsAgreement;
 import com.example.live_backend.global.error.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -10,9 +12,6 @@ import com.example.live_backend.domain.auth.dto.response.AuthUserDto;
 import com.example.live_backend.domain.auth.dto.request.KakaoLoginRequestDto;
 import com.example.live_backend.domain.memeber.Gender;
 import com.example.live_backend.domain.memeber.Role;
-import com.example.live_backend.domain.memeber.dto.MemberProfileRequestDto;
-import com.example.live_backend.domain.memeber.dto.MemberResponseDto;
-import com.example.live_backend.domain.memeber.dto.NicknameCheckResponseDto;
 import com.example.live_backend.domain.memeber.entity.Member;
 import com.example.live_backend.domain.memeber.entity.Occupation;
 import com.example.live_backend.domain.memeber.entity.vo.BirthDate;
@@ -164,4 +163,27 @@ public class MemberService {
 		member.updateProfile(updatedProfile);
 	}
 
+    @Transactional
+    public TermsAgreementResponseDto updateTermsAgreement(TermsAgreementRequestDto dto, Long userId) {
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        TermsAgreement termsAgreement = TermsAgreement.from(dto);
+        member.updateTermsAgreement(termsAgreement);
+
+        return TermsAgreementResponseDto.from(termsAgreement);
+    }
+
+    @Transactional(readOnly = true)
+    public TermsAgreementResponseDto getTermsAgreement(Long userId) {
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        TermsAgreement terms = member.getTermsAgreement();
+        if (terms == null) {
+            return TermsAgreementResponseDto.from(new TermsAgreement(false, false, false));
+        }
+
+        return TermsAgreementResponseDto.from(terms);
+    }
 }


### PR DESCRIPTION
### ✅ PR 타입 (하나 이상 선택해주세요)

- [x]  기능 추가
- [ ]  기능 삭제
- [ ]  리팩토링 / 코드 개선
- [ ]  의존성 / 환경 설정 변경
- [ ]  버그 수정
- [ ]  기타 (하단에 설명)

&nbsp;
### ✨ 어떤 내용인가요?
> 회원가입 이후 진행하는 약관 동의/미동의 내용을 `member` 테이블에 저장하고, 내역을 조회하는 API를 구현한다.

&nbsp;
### 🔍 작업 상세 내용

[x] `TermsAgreement` VO 추가
      - 서비스 이용 약관, 개인정보 수집, 위치정보 약관 동의 여부 저장
[x] Member 엔티티에 약관 동의 필드 추가
      - `@Embedded`로 `TermsAgreement` 추가
[x] 약관 동의 API 구현
      - POST /api/members/terms : 약관 동의 등록/수정
      - GET /api/members/terms : 약관 동의 상태 조회

&nbsp;
### 💬 리뷰어에게 전달할 내용 (선택)

> 테스트 방법, 주의 깊게 봐줬으면 하는 부분 등
> 

&nbsp;
### 🔗 관련 이슈

- Resolves: #121 